### PR TITLE
Clean up upstream remote on process exit

### DIFF
--- a/.changeset/cleanup-upstream-remote-on-exit.md
+++ b/.changeset/cleanup-upstream-remote-on-exit.md
@@ -1,0 +1,5 @@
+---
+"ai-hero-cli": patch
+---
+
+Clean up the upstream remote and local tracking branch when CLI commands finish. Only cleans up resources that the CLI added -- if the user already had an upstream remote configured, it is left untouched.

--- a/qa/test-reset-from-random-repo.sh
+++ b/qa/test-reset-from-random-repo.sh
@@ -12,3 +12,5 @@ git add .
 git commit -m "Initial commit"
 git checkout -b my-dev-branch
 node ../../ai/ai-hero-cli/dist/bin.cjs reset --branch live-run-through --upstream https://github.com/ai-hero-dev/cohort-003-project.git
+echo "Remotes - there should only be origin:"
+git remote

--- a/src/cherry-pick.ts
+++ b/src/cherry-pick.ts
@@ -14,6 +14,7 @@ import {
 import { GitService, GitServiceConfig } from "./git-service.js";
 import { cwdOption } from "./options.js";
 import { PromptService } from "./prompt-service.js";
+import { withUpstreamCleanup } from "./upstream-cleanup.js";
 
 /**
  * Core cherry-pick logic, extracted for testability.
@@ -28,65 +29,68 @@ export const runCherryPick = ({
   lessonId: Option.Option<string>;
   upstream: string;
 }) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
-    const promptService = yield* PromptService;
+  withUpstreamCleanup(
+    { upstream, targetBranch: branch },
+    Effect.gen(function* () {
+      const git = yield* GitService;
+      const promptService = yield* PromptService;
 
-    // Validate git repository
-    yield* git.ensureIsGitRepo();
+      // Validate git repository
+      yield* git.ensureIsGitRepo();
 
-    const currentBranch = yield* ensureNotOnProtectedBranch("cherry-pick");
+      const currentBranch = yield* ensureNotOnProtectedBranch("cherry-pick");
 
-    // Set up upstream remote
-    yield* git.setUpstreamRemote(upstream);
+      // Set up upstream remote
+      yield* git.setUpstreamRemote(upstream);
 
-    yield* git.ensureUpstreamBranchConnected({
-      targetBranch: branch,
-    });
-
-    const { commit: targetCommit, lessonId: selectedLessonId } =
-      yield* selectLessonCommit({
-        branch,
-        lessonId,
-        promptMessage:
-          "Which lesson do you want to cherry-pick? (type to search)",
-        excludeCurrentBranch: true,
+      yield* git.ensureUpstreamBranchConnected({
+        targetBranch: branch,
       });
 
-    // Check if current branch is the target branch
-    if (currentBranch === branch) {
-      return yield* new InvalidBranchOperationError({
-        message: `Cannot cherry-pick when on target branch "${branch}"`,
-      });
-    }
+      const { commit: targetCommit, lessonId: selectedLessonId } =
+        yield* selectLessonCommit({
+          branch,
+          lessonId,
+          promptMessage:
+            "Which lesson do you want to cherry-pick? (type to search)",
+          excludeCurrentBranch: true,
+        });
 
-    // Check if current branch is main
-    if (currentBranch === "main") {
+      // Check if current branch is the target branch
+      if (currentBranch === branch) {
+        return yield* new InvalidBranchOperationError({
+          message: `Cannot cherry-pick when on target branch "${branch}"`,
+        });
+      }
+
+      // Check if current branch is main
+      if (currentBranch === "main") {
+        yield* Console.log(
+          "You cannot cherry-pick onto the main branch."
+        );
+
+        const branchName = yield* promptService.inputBranchName(
+          "working"
+        );
+
+        yield* git.checkoutNewBranch(branchName);
+
+        yield* Console.log(
+          `✓ Created and switched to ${branchName}`
+        );
+      }
+
       yield* Console.log(
-        "You cannot cherry-pick onto the main branch."
+        `Cherry-picking ${targetCommit.sha} onto current branch...\n`
       );
 
-      const branchName = yield* promptService.inputBranchName(
-        "working"
-      );
-
-      yield* git.checkoutNewBranch(branchName);
+      yield* git.cherryPick(targetCommit.sha);
 
       yield* Console.log(
-        `✓ Created and switched to ${branchName}`
+        `\n✓ Successfully cherry-picked lesson ${selectedLessonId}`
       );
-    }
-
-    yield* Console.log(
-      `Cherry-picking ${targetCommit.sha} onto current branch...\n`
-    );
-
-    yield* git.cherryPick(targetCommit.sha);
-
-    yield* Console.log(
-      `\n✓ Successfully cherry-picked lesson ${selectedLessonId}`
-    );
-  });
+    })
+  );
 
 export const cherryPick = CLICommand.make(
   "cherry-pick",

--- a/src/git-service/git-service-impl.ts
+++ b/src/git-service/git-service-impl.ts
@@ -67,6 +67,16 @@ export const makeGitService = Effect.gen(function* () {
         return yield* Command.exitCode(command);
       });
 
+      const runCommandSilentExitCode = Effect.fn(
+        "runCommandSilentExitCode"
+      )(function* (...commandArgs: [string, ...Array<string>]) {
+        const cwd = config.cwd;
+        const command = Command.make(...commandArgs).pipe(
+          Command.workingDirectory(cwd)
+        );
+        return yield* Command.exitCode(command);
+      });
+
       const resetHard = Effect.fn("resetHard")(function* (
         sha: string
       ) {
@@ -533,6 +543,38 @@ export const makeGitService = Effect.gen(function* () {
             }
           }
         ),
+        hasRemote: Effect.fn("hasRemote")(function* (
+          name: string
+        ) {
+          const exitCode = yield* runCommandSilentExitCode(
+            "git",
+            "remote",
+            "get-url",
+            name
+          );
+          return exitCode === 0;
+        }),
+        removeRemote: Effect.fn("removeRemote")(function* (
+          name: string
+        ) {
+          yield* runCommandSilentExitCode(
+            "git",
+            "remote",
+            "remove",
+            name
+          );
+        }),
+        hasLocalBranch: Effect.fn("hasLocalBranch")(function* (
+          name: string
+        ) {
+          const exitCode = yield* runCommandSilentExitCode(
+            "git",
+            "rev-parse",
+            "--verify",
+            `refs/heads/${name}`
+          );
+          return exitCode === 0;
+        }),
       };
     });
 

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -4,6 +4,7 @@ import { ensureNotOnProtectedBranch } from "./errors.js";
 import { GitService, GitServiceConfig } from "./git-service.js";
 import { cwdOption } from "./options.js";
 import { PromptService } from "./prompt-service.js";
+import { withUpstreamCleanup } from "./upstream-cleanup.js";
 
 export class UncommittedChangesError extends Data.TaggedError(
   "UncommittedChangesError"
@@ -15,52 +16,55 @@ export class UncommittedChangesError extends Data.TaggedError(
  * Core pull logic, extracted for testability.
  */
 export const runPull = (opts: { upstream: string }) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
+  withUpstreamCleanup(
+    { upstream: opts.upstream },
+    Effect.gen(function* () {
+      const git = yield* GitService;
 
-    // Validate git repository
-    yield* git.ensureIsGitRepo();
+      // Validate git repository
+      yield* git.ensureIsGitRepo();
 
-    let workingBranch = yield* ensureNotOnProtectedBranch("pull");
-    if (workingBranch === "main") {
-      const promptService = yield* PromptService;
+      let workingBranch = yield* ensureNotOnProtectedBranch("pull");
+      if (workingBranch === "main") {
+        const promptService = yield* PromptService;
+        yield* Console.log(
+          "You're on the main branch. To avoid losing work, create a dev branch to pull upstream changes into."
+        );
+        const branchName = yield* promptService.inputBranchName(
+          "working"
+        );
+        yield* git.checkoutNewBranch(branchName);
+        workingBranch = branchName;
+      }
+
+      // Check for uncommitted changes
+      const { hasUncommittedChanges, statusOutput } =
+        yield* git.getUncommittedChanges();
+
+      if (hasUncommittedChanges) {
+        return yield* new UncommittedChangesError({
+          statusOutput,
+        });
+      }
+
+      // Set up upstream remote
+      yield* git.setUpstreamRemote(opts.upstream);
+
+      // Fetch main from upstream
+      yield* Console.log("Fetching main from upstream...");
+      yield* git.fetch("upstream", "main");
+
+      // Merge upstream/main into current branch
       yield* Console.log(
-        "You're on the main branch. To avoid losing work, create a dev branch to pull upstream changes into."
+        `Merging upstream/main into ${workingBranch}...`
       );
-      const branchName = yield* promptService.inputBranchName(
-        "working"
+      yield* git.merge("upstream/main");
+
+      yield* Console.log(
+        `\n✓ Successfully merged upstream/main into ${workingBranch}`
       );
-      yield* git.checkoutNewBranch(branchName);
-      workingBranch = branchName;
-    }
-
-    // Check for uncommitted changes
-    const { hasUncommittedChanges, statusOutput } =
-      yield* git.getUncommittedChanges();
-
-    if (hasUncommittedChanges) {
-      return yield* new UncommittedChangesError({
-        statusOutput,
-      });
-    }
-
-    // Set up upstream remote
-    yield* git.setUpstreamRemote(opts.upstream);
-
-    // Fetch main from upstream
-    yield* Console.log("Fetching main from upstream...");
-    yield* git.fetch("upstream", "main");
-
-    // Merge upstream/main into current branch
-    yield* Console.log(
-      `Merging upstream/main into ${workingBranch}...`
-    );
-    yield* git.merge("upstream/main");
-
-    yield* Console.log(
-      `\n✓ Successfully merged upstream/main into ${workingBranch}`
-    );
-  });
+    })
+  );
 
 export const pull = CLICommand.make(
   "pull",

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -13,6 +13,7 @@ import {
 import { GitService, GitServiceConfig } from "./git-service.js";
 import { cwdOption } from "./options.js";
 import { PromptService } from "./prompt-service.js";
+import { withUpstreamCleanup } from "./upstream-cleanup.js";
 
 /**
  * Core reset logic, extracted for testability.
@@ -29,140 +30,143 @@ export const runReset = ({
   demo: boolean;
   upstream: string;
 }) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
-    const promptService = yield* PromptService;
+  withUpstreamCleanup(
+    { upstream, targetBranch: branch },
+    Effect.gen(function* () {
+      const git = yield* GitService;
+      const promptService = yield* PromptService;
 
-    // Validate git repository
-    yield* git.ensureIsGitRepo();
+      // Validate git repository
+      yield* git.ensureIsGitRepo();
 
-    const currentBranch = yield* ensureNotOnProtectedBranch("reset");
+      const currentBranch = yield* ensureNotOnProtectedBranch("reset");
 
-    // Set up upstream remote
-    yield* git.setUpstreamRemote(upstream);
+      // Set up upstream remote
+      yield* git.setUpstreamRemote(upstream);
 
-    yield* git.ensureUpstreamBranchConnected({
-      targetBranch: branch,
-    });
-
-    // Determine if this is a "reset to main" operation
-    const isExplicitMain =
-      Option.isSome(lessonId) && lessonId.value === "main";
-
-    let commitToUse: string;
-    let selectedLessonId: string;
-
-    if (isExplicitMain) {
-      yield* git.fetch("upstream", "main");
-      commitToUse = yield* git.revParse("upstream/main");
-      selectedLessonId = "main";
-    } else {
-      const result = yield* selectLessonCommit({
-        branch,
-        lessonId,
-        promptMessage:
-          "Which lesson do you want to reset to? (type to search)",
-        excludeCurrentBranch: false,
-        extraChoices: [
-          { lessonId: "main", message: "Reset to the starting point" },
-        ],
+      yield* git.ensureUpstreamBranchConnected({
+        targetBranch: branch,
       });
 
-      if (result.lessonId === "main") {
+      // Determine if this is a "reset to main" operation
+      const isExplicitMain =
+        Option.isSome(lessonId) && lessonId.value === "main";
+
+      let commitToUse: string;
+      let selectedLessonId: string;
+
+      if (isExplicitMain) {
         yield* git.fetch("upstream", "main");
         commitToUse = yield* git.revParse("upstream/main");
         selectedLessonId = "main";
       } else {
-        commitToUse = result.commit.sha;
-        selectedLessonId = result.lessonId;
+        const result = yield* selectLessonCommit({
+          branch,
+          lessonId,
+          promptMessage:
+            "Which lesson do you want to reset to? (type to search)",
+          excludeCurrentBranch: false,
+          extraChoices: [
+            { lessonId: "main", message: "Reset to the starting point" },
+          ],
+        });
+
+        if (result.lessonId === "main") {
+          yield* git.fetch("upstream", "main");
+          commitToUse = yield* git.revParse("upstream/main");
+          selectedLessonId = "main";
+        } else {
+          commitToUse = result.commit.sha;
+          selectedLessonId = result.lessonId;
+        }
       }
-    }
 
-    const isResetToMain = selectedLessonId === "main";
+      const isResetToMain = selectedLessonId === "main";
 
-    // Cannot reset to main while on main
-    if (isResetToMain && currentBranch === "main") {
-      return yield* new InvalidBranchOperationError({
-        message:
-          "Cannot reset to main while on the main branch. Create a new branch first.",
-      });
-    }
-
-    // Prompt for action (skip in demo mode)
-    let action: "reset-current" | "create-branch";
-    if (currentBranch === "main") {
-      yield* Console.log(
-        "You cannot reset the main branch. Creating a new branch..."
-      );
-      action = "create-branch";
-    } else if (demo) {
-      action = "reset-current";
-    } else {
-      action = yield* promptService.selectResetAction(
-        currentBranch
-      );
-    }
-
-    if (action === "reset-current") {
-      // Check if current branch is the target branch
-      if (currentBranch === branch) {
+      // Cannot reset to main while on main
+      if (isResetToMain && currentBranch === "main") {
         return yield* new InvalidBranchOperationError({
-          message: `Cannot reset current branch when on target branch "${branch}"`,
+          message:
+            "Cannot reset to main while on the main branch. Create a new branch first.",
         });
       }
-    }
 
-    if (action === "create-branch") {
-      const branchName = yield* promptService.inputBranchName(
-        "new"
-      );
-
-      yield* Console.log(
-        `Creating branch ${branchName} from ${selectedLessonId}...`
-      );
-
-      yield* git.checkoutNewBranchAt(branchName, commitToUse);
-
-      yield* Console.log(
-        `✓ Created and checked out branch: ${branchName}`
-      );
-      return;
-    }
-
-    // Reset current branch - check for unstaged changes (skip in demo mode)
-    if (!demo) {
-      const { hasUncommittedChanges, statusOutput } =
-        yield* git.getUncommittedChanges();
-
-      if (hasUncommittedChanges) {
+      // Prompt for action (skip in demo mode)
+      let action: "reset-current" | "create-branch";
+      if (currentBranch === "main") {
         yield* Console.log(
-          "\nWarning: You have uncommitted changes:"
+          "You cannot reset the main branch. Creating a new branch..."
         );
-        yield* Console.log(statusOutput);
-
-        yield* promptService.confirmResetWithUncommittedChanges();
+        action = "create-branch";
+      } else if (demo) {
+        action = "reset-current";
+      } else {
+        action = yield* promptService.selectResetAction(
+          currentBranch
+        );
       }
-    }
 
-    // Reset to target commit
-    yield* Console.log(
-      `Resetting to ${selectedLessonId}...`
-    );
+      if (action === "reset-current") {
+        // Check if current branch is the target branch
+        if (currentBranch === branch) {
+          return yield* new InvalidBranchOperationError({
+            message: `Cannot reset current branch when on target branch "${branch}"`,
+          });
+        }
+      }
 
-    if (demo) {
-      yield* git.applyAsUnstagedChanges(commitToUse);
+      if (action === "create-branch") {
+        const branchName = yield* promptService.inputBranchName(
+          "new"
+        );
 
+        yield* Console.log(
+          `Creating branch ${branchName} from ${selectedLessonId}...`
+        );
+
+        yield* git.checkoutNewBranchAt(branchName, commitToUse);
+
+        yield* Console.log(
+          `✓ Created and checked out branch: ${branchName}`
+        );
+        return;
+      }
+
+      // Reset current branch - check for unstaged changes (skip in demo mode)
+      if (!demo) {
+        const { hasUncommittedChanges, statusOutput } =
+          yield* git.getUncommittedChanges();
+
+        if (hasUncommittedChanges) {
+          yield* Console.log(
+            "\nWarning: You have uncommitted changes:"
+          );
+          yield* Console.log(statusOutput);
+
+          yield* promptService.confirmResetWithUncommittedChanges();
+        }
+      }
+
+      // Reset to target commit
       yield* Console.log(
-        `✓ Demo mode: Reset to ${selectedLessonId} with unstaged changes`
+        `Resetting to ${selectedLessonId}...`
       );
-    } else {
-      yield* git.resetHard(commitToUse);
 
-      yield* Console.log(
-        `✓ Reset to ${selectedLessonId}`
-      );
-    }
-  });
+      if (demo) {
+        yield* git.applyAsUnstagedChanges(commitToUse);
+
+        yield* Console.log(
+          `✓ Demo mode: Reset to ${selectedLessonId} with unstaged changes`
+        );
+      } else {
+        yield* git.resetHard(commitToUse);
+
+        yield* Console.log(
+          `✓ Reset to ${selectedLessonId}`
+        );
+      }
+    })
+  );
 
 export const reset = CLICommand.make(
   "reset",

--- a/src/upstream-cleanup.ts
+++ b/src/upstream-cleanup.ts
@@ -12,7 +12,7 @@ export const withUpstreamCleanup = <A, E, R>(
     targetBranch?: string;
   },
   body: Effect.Effect<A, E, R>
-): Effect.Effect<A, E, R | GitService> =>
+) =>
   Effect.gen(function* () {
     const git = yield* GitService;
 

--- a/src/upstream-cleanup.ts
+++ b/src/upstream-cleanup.ts
@@ -1,0 +1,47 @@
+import { Effect } from "effect";
+import { GitService } from "./git-service.js";
+
+/**
+ * Wraps a command effect with upstream remote/branch cleanup.
+ * Snapshots whether the `upstream` remote and the target branch exist
+ * before running, then cleans up only what the command added.
+ */
+export const withUpstreamCleanup = <A, E, R>(
+  opts: {
+    upstream: string;
+    targetBranch?: string;
+  },
+  body: Effect.Effect<A, E, R>
+): Effect.Effect<A, E, R | GitService> =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    // Snapshot pre-existing state
+    const remoteExisted = yield* git.hasRemote("upstream");
+    const branchExisted = opts.targetBranch
+      ? yield* git.hasLocalBranch(opts.targetBranch)
+      : false;
+
+    // Run the body with cleanup guaranteed
+    return yield* body.pipe(
+      Effect.ensuring(
+        Effect.gen(function* () {
+          const git = yield* GitService;
+
+          // Clean up branch first (before removing remote)
+          if (!branchExisted && opts.targetBranch) {
+            yield* git
+              .deleteBranch(opts.targetBranch)
+              .pipe(Effect.catchAll(() => Effect.void));
+          }
+
+          // Clean up remote (also removes upstream/* tracking refs)
+          if (!remoteExisted) {
+            yield* git
+              .removeRemote("upstream")
+              .pipe(Effect.catchAll(() => Effect.void));
+          }
+        })
+      )
+    );
+  });

--- a/test/helpers/create-test-repo.ts
+++ b/test/helpers/create-test-repo.ts
@@ -88,6 +88,8 @@ export const createTestRepo = (): TestRepoBuilder => {
       // Create working repo and add remote
       fs.mkdirSync(workDir);
       git(workDir, "init");
+      git(workDir, "config", "user.name", "Test");
+      git(workDir, "config", "user.email", "test@test.com");
       git(workDir, "remote", "add", remoteName, bareDir);
 
       // Track commit SHAs per branch for withWorkingBranch

--- a/test/pull-e2e.test.ts
+++ b/test/pull-e2e.test.ts
@@ -225,7 +225,7 @@ describe("pull (e2e)", () => {
 
   describe("upstream remote setup", () => {
     it.effect(
-      "should create upstream remote if it does not exist",
+      "should create upstream remote temporarily and clean it up after pull",
       () =>
         Effect.gen(function* () {
           const repo = createTestRepo()
@@ -266,14 +266,13 @@ describe("pull (e2e)", () => {
             )
           ).toBe(true);
 
-          // Verify the remote was created with the correct URL
+          // Verify the remote was cleaned up (it didn't exist before)
           const remotes = git(
             repo.workingDir,
             "remote",
             "-v"
           );
-          expect(remotes).toContain("upstream");
-          expect(remotes).toContain(bareRepoPath);
+          expect(remotes).not.toContain("upstream");
         })
     );
 

--- a/test/pull-e2e.test.ts
+++ b/test/pull-e2e.test.ts
@@ -361,6 +361,13 @@ describe("pull (e2e)", () => {
           const localTmpDir = `${upstreamRepo.workingDir}/../local-unrelated`;
           fs.mkdirSync(localTmpDir);
           git(localTmpDir, "init");
+          git(localTmpDir, "config", "user.name", "Test");
+          git(
+            localTmpDir,
+            "config",
+            "user.email",
+            "test@test.com"
+          );
           fs.writeFileSync(
             `${localTmpDir}/README.md`,
             "# My project"

--- a/test/reset-e2e.test.ts
+++ b/test/reset-e2e.test.ts
@@ -1331,4 +1331,208 @@ describe("reset (e2e)", () => {
     );
   });
 
+  describe("upstream cleanup", () => {
+    it.effect(
+      "should clean up upstream remote and local branch when they did not exist before",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("live-run-through", [
+              commit("01.01.01 Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          const bareRepoPath = getBareRepoPath(repo.workingDir);
+
+          // Remove upstream remote and local live-run-through branch
+          // so the CLI has to create them
+          git(repo.workingDir, "remote", "remove", "upstream");
+          git(
+            repo.workingDir,
+            "branch",
+            "-D",
+            "live-run-through"
+          );
+
+          const mockPromptService = fromPartial<PromptService>({
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.some("01.01.01"),
+            demo: false,
+            upstream: bareRepoPath,
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          // Verify the reset worked
+          const content = fs.readFileSync(
+            `${repo.workingDir}/src/01.ts`,
+            "utf-8"
+          );
+          expect(content).toBe("// arrays intro");
+
+          // Verify upstream remote was cleaned up
+          const remotes = git(
+            repo.workingDir,
+            "remote",
+            "-v"
+          );
+          expect(remotes).not.toContain("upstream");
+
+          // Verify local live-run-through branch was cleaned up
+          const branches = git(
+            repo.workingDir,
+            "branch",
+            "--list"
+          );
+          expect(branches).not.toContain("live-run-through");
+        })
+    );
+
+    it.effect(
+      "should preserve upstream remote and local branch when they existed before",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("live-run-through", [
+              commit("01.01.01 Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          // upstream remote and live-run-through branch already exist
+          // from the test repo builder
+
+          const mockPromptService = fromPartial<PromptService>({
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.some("01.01.01"),
+            demo: false,
+            upstream: getBareRepoPath(repo.workingDir),
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          // Verify upstream remote is still present
+          const remotes = git(
+            repo.workingDir,
+            "remote",
+            "-v"
+          );
+          expect(remotes).toContain("upstream");
+
+          // Verify local live-run-through branch is still present
+          const branches = git(
+            repo.workingDir,
+            "branch",
+            "--list"
+          );
+          expect(branches).toContain("live-run-through");
+        })
+    );
+
+    it.effect(
+      "should clean up even when the command fails",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("live-run-through", [
+              commit("01.01.01 Arrays intro", {
+                "src/01.ts": "// arrays",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+
+          const bareRepoPath = getBareRepoPath(repo.workingDir);
+
+          // Remove upstream so the CLI creates it
+          git(repo.workingDir, "remote", "remove", "upstream");
+          git(
+            repo.workingDir,
+            "branch",
+            "-D",
+            "live-run-through"
+          );
+
+          const mockPromptService =
+            fromPartial<PromptService>({});
+
+          // Use a non-existent lesson ID to trigger CommitNotFoundError
+          const result = yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.some("99.99.99"),
+            demo: false,
+            upstream: bareRepoPath,
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            ),
+            Effect.flip
+          );
+
+          expect(result._tag).toBe("CommitNotFoundError");
+
+          // Verify upstream remote was still cleaned up despite error
+          const remotes = git(
+            repo.workingDir,
+            "remote",
+            "-v"
+          );
+          expect(remotes).not.toContain("upstream");
+
+          // Verify local branch was still cleaned up despite error
+          const branches = git(
+            repo.workingDir,
+            "branch",
+            "--list"
+          );
+          expect(branches).not.toContain("live-run-through");
+        })
+    );
+  });
+
 });


### PR DESCRIPTION
## Summary

- When CLI commands (reset, cherry-pick, pull) add an `upstream` git remote, it is now automatically cleaned up when the command finishes
- Only removes resources the CLI added — if the user already had an `upstream` remote configured, it is left untouched
- Also cleans up the local tracking branch (e.g. `live-run-through`) if it was created by the CLI
- Cleanup runs even when the command fails (uses `Effect.ensuring` finalizer semantics)

## Changes

- Added `hasRemote`, `removeRemote`, `hasLocalBranch` methods to GitService
- Created `withUpstreamCleanup` helper that wraps command effects with acquire/release semantics
- Wrapped `runReset`, `runCherryPick`, `runPull` with the cleanup helper
- Added 3 E2E tests: cleanup when not pre-existing, preserve when pre-existing, cleanup on error

## Test plan

- [x] All 95 tests pass (92 existing + 3 new)
- [x] Type-check passes
- [x] Verified cleanup removes remote when CLI added it
- [x] Verified cleanup preserves remote when it already existed
- [x] Verified cleanup runs even on command error (CommitNotFoundError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)