### PR TITLE
feat: accept lesson slugs in reset and cherry-pick

### DIFF
--- a/.changeset/slug-lesson-ids.md
+++ b/.changeset/slug-lesson-ids.md
@@ -1,0 +1,11 @@
+---
+"ai-hero-cli": minor
+---
+
+Accept lesson **slugs** (not just numeric `NN.NN.NN` ids) in `reset` and `cherry-pick`. A lesson id is now "the token before the first `": "` in a commit message", so a slug (`add-settings-json`), a numeric id (`06.06.01`), and anything else are handled by one generic parser — numeric is just a slug that happens to have dots.
+
+To keep base and conventional-commit lines (`chore: …`, `fix: …`) from masquerading as lessons now that any `token: message` prefix is an id, the candidate set is scoped to the lesson stack `upstream/main..<branch>` instead of the branch's full history — a structural fence, no denylist or slug-shape heuristic. Repos without an `upstream/main` to anchor on fall back to full-branch history (the base `initial` commit has no `": "` and drops out anyway).
+
+Candidates now list in commit order (teaching order carried by the stack) rather than sorted by id, and duplicate-slug resolution picks the latest (newest) matching commit. Numeric ids keep their existing ergonomics — `1.1.1` still normalizes to `01.01.01`.
+
+Known limitation: a non-lesson commit deliberately stacked *inside* `main..<branch>` (e.g. a stray `chore:` reconcile commit) will still surface as a lesson — the fence removes base commits, not stray commits living on the stack. Keep the stack a clean set of lesson slugs.

--- a/src/commit-utils.ts
+++ b/src/commit-utils.ts
@@ -3,8 +3,12 @@ import { GitService } from "./git-service.js";
 import { PromptService } from "./prompt-service.js";
 
 /**
- * Normalizes a lesson ID to the standard format (e.g., "1.1.1" -> "01.01.01").
- * Handles various input formats like "1.1.1", "01.1.01", "1-1-1", etc.
+ * Normalizes a numeric lesson ID to the standard format (e.g., "1.1.1" -> "01.01.01").
+ * Handles input formats like "1.1.1", "01.1.01", "1-1-1", etc.
+ *
+ * Returns null for anything that is not a numeric section.lesson.step id — so
+ * a slug passes straight through the caller untouched. Kept as a pass-through
+ * so numeric ids stay ergonomic while repos migrate to slugs.
  */
 export const normalizeLessonId = (lessonId: string): string | null => {
   // Match pattern like 1.1.1, 01.01.01, 1-1-1, etc.
@@ -25,13 +29,25 @@ export class CommitNotFoundError extends Data.TaggedError(
 type ParsedCommit = {
   /** Short commit SHA */
   sha: string;
-  /** Commit message with lesson ID prefix removed (e.g., "Add new feature" from "01.01.01 Add new feature") */
+  /** Commit message with the lesson-id prefix removed (e.g., "Add new feature" from "add-feature: Add new feature") */
   message: string;
-  /** Normalized lesson ID (e.g., "01.01.01") extracted from commit message, or null if no lesson ID found */
+  /** Lesson id — everything before the first ": " — or null when the commit has no such prefix */
   lessonId: string | null;
 };
 
-const parseCommits = (
+/** The parse boundary: everything before the first ": " is the lesson id. */
+const LESSON_ID_BOUNDARY = ": ";
+
+/**
+ * Parses `git log --oneline` output into commits, extracting each lesson id as
+ * the token before the first ": ". A slug (`add-settings-json`), a numeric id
+ * (`06.06.01`), and a conventional-commit type (`fix`) are all just "the token
+ * before the colon" — there is no format-specific logic here. Commits with no
+ * ": " (a bare `initial`, a `WIP foo`) get a null id and are treated as
+ * non-lessons. Fencing out base/conventional commits is the range's job (see
+ * getCandidateCommits), not this function's.
+ */
+export const parseCommits = (
   commitHistory: string
 ): Array<ParsedCommit> => {
   return commitHistory
@@ -42,32 +58,72 @@ const parseCommits = (
       const [sha, ...messageParts] = line.split(" ");
       const fullMessage = messageParts.join(" ");
 
-      // Extract lesson ID - match pattern like 01.01.01, 1.1.1, etc.
-      const lessonMatch = fullMessage.match(
-        /^(\d+)[.-](\d+)[.-](\d+)\s*/
+      const boundaryIndex = fullMessage.indexOf(
+        LESSON_ID_BOUNDARY
       );
-      const extractedLessonId = lessonMatch
-        ? `${lessonMatch[1]!.padStart(
-            2,
-            "0"
-          )}.${lessonMatch[2]!.padStart(
-            2,
-            "0"
-          )}.${lessonMatch[3]!.padStart(2, "0")}`
-        : null;
 
-      // Remove lesson ID prefix from message
-      const message = lessonMatch
-        ? fullMessage.slice(lessonMatch[0].length).trim()
-        : fullMessage;
+      // boundaryIndex > 0 so the id is non-empty (a leading ": " is not an id).
+      const lessonId =
+        boundaryIndex > 0
+          ? fullMessage.slice(0, boundaryIndex)
+          : null;
+
+      const message =
+        boundaryIndex > 0
+          ? fullMessage
+              .slice(boundaryIndex + LESSON_ID_BOUNDARY.length)
+              .trim()
+          : fullMessage;
 
       return {
         sha: sha!,
         message,
-        lessonId: extractedLessonId,
+        lessonId,
       };
     });
 };
+
+/**
+ * Builds the lesson-commit candidate set for `branch`, in teaching order
+ * (oldest -> newest).
+ *
+ * Lessons are exactly the commits in `upstream/main..branch` — the lesson
+ * stack. Scoping to that range structurally excludes every base commit
+ * (including conventional-commit-shaped ones like `chore: ...` that live on
+ * main) regardless of message shape, so no denylist or slug-shape heuristic is
+ * needed.
+ *
+ * When there is no `upstream/main` to anchor on, we fall back to the branch's
+ * full history: the base `initial` commit has no ": " and drops out as a
+ * non-lesson anyway.
+ *
+ * Precondition: the `upstream` remote is live. Callers (`reset`, `cherry-pick`)
+ * set it up under `withUpstreamCleanup` before calling `selectLessonCommit`,
+ * which owns the remote's lifecycle — this function only reads through it. The
+ * `upstream/main` fetch lands the commit objects permanently; the resolved SHA
+ * outlives the ephemeral remote once the caller tears it down.
+ */
+const getCandidateCommits = (branch: string) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    const hasUpstreamMain = yield* git
+      .fetch("upstream", "main")
+      .pipe(
+        Effect.as(true),
+        Effect.catchTag("FailedToFetchError", () =>
+          Effect.succeed(false)
+        )
+      );
+
+    const range = hasUpstreamMain
+      ? `upstream/main..${branch}`
+      : branch;
+
+    const history = yield* git.getLogOnelineReverse(range);
+
+    return parseCommits(history);
+  });
 
 export const selectLessonCommit = ({
   branch,
@@ -86,40 +142,36 @@ export const selectLessonCommit = ({
     const gitService = yield* GitService;
     const promptService = yield* PromptService;
 
-    // Search commit history for lesson ID
-    let commits: Array<ParsedCommit>;
+    // Candidate lessons, scoped to the lesson stack, in teaching order.
+    let commits: Array<ParsedCommit> =
+      yield* getCandidateCommits(branch);
 
     if (excludeCurrentBranch) {
-      // Get commits from current branch to extract lesson IDs
-      const currentBranchHistory = yield* gitService.getLogOneline("HEAD");
-      const currentBranchCommits = parseCommits(currentBranchHistory);
+      // Extract lesson ids already applied on the current branch and drop them
+      // from the candidate set. Scanning HEAD's full history is fine — a stray
+      // non-lesson prefix there simply matches no candidate.
+      const currentBranchHistory =
+        yield* gitService.getLogOneline("HEAD");
+      const currentBranchCommits = parseCommits(
+        currentBranchHistory
+      );
 
-      // Extract lesson IDs from current branch (only commits with lesson IDs)
       const currentLessonIds = new Set(
         currentBranchCommits
           .filter((c) => c.lessonId !== null)
           .map((c) => c.lessonId!)
       );
 
-      // Get commits from target branch
-      const targetBranchHistory = yield* gitService.getLogOneline(branch);
-      const allTargetCommits = parseCommits(targetBranchHistory);
-
-      // Filter out commits with lesson IDs that exist on current branch
-      commits = allTargetCommits.filter(
+      commits = commits.filter(
         (c) => !c.lessonId || !currentLessonIds.has(c.lessonId)
       );
-    } else {
-      const commitHistory = yield* gitService.getLogOneline(branch);
-
-      commits = parseCommits(commitHistory);
     }
 
     // Get selected lesson ID
     let selectedLessonId: string;
 
     if (Option.isSome(lessonId)) {
-      // Normalize the user-provided lesson ID (e.g., "1.1.1" -> "01.01.01")
+      // Normalize numeric input (e.g. "1.1.1" -> "01.01.01"); slugs pass through.
       const normalized = normalizeLessonId(lessonId.value);
       selectedLessonId = normalized ?? lessonId.value;
       yield* Console.log(
@@ -140,14 +192,11 @@ export const selectLessonCommit = ({
         );
       }
 
-      // Sort commits by lesson ID ascending
-      const sortedCommits = commitsWithLessonIds.sort((a, b) => {
-        return a.lessonId!.localeCompare(b.lessonId!);
-      });
-
+      // Teaching order is commit order (oldest -> newest), carried by the stack
+      // itself — no sort. Slugs deliberately carry no ordinal.
       const choices = [
         ...(extraChoices ?? []),
-        ...sortedCommits.map((commit) => ({
+        ...commitsWithLessonIds.map((commit) => ({
           lessonId: commit.lessonId!,
           message: commit.message,
         })),
@@ -182,7 +231,8 @@ export const selectLessonCommit = ({
       });
     }
 
-    // If multiple commits found, choose the latest one (last in the list)
+    // Latest wins: candidates are oldest -> newest, so the last match is the
+    // newest commit carrying this id (duplicate slugs are a maintainer trap).
     const targetCommit =
       matchingCommits[matchingCommits.length - 1]!;
 
@@ -195,4 +245,3 @@ export const selectLessonCommit = ({
       lessonId: selectedLessonId,
     };
   });
-

--- a/test/cherry-pick-e2e.test.ts
+++ b/test/cherry-pick-e2e.test.ts
@@ -86,10 +86,10 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays intro",
               }),
-              commit("01.01.02 Arrays advanced", {
+              commit("01.01.02: Arrays advanced", {
                 "src/02.ts": "// arrays advanced",
               }),
             ])
@@ -146,10 +146,10 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
-              commit("01.02.01 Objects intro", {
+              commit("01.02.01: Objects intro", {
                 "src/02.ts": "// objects",
               }),
             ])
@@ -194,13 +194,13 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
-              commit("01.01.02 Arrays advanced", {
+              commit("01.01.02: Arrays advanced", {
                 "src/02.ts": "// arrays advanced",
               }),
-              commit("01.02.01 Objects intro", {
+              commit("01.02.01: Objects intro", {
                 "src/03.ts": "// objects",
               }),
             ])
@@ -278,10 +278,10 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 First version", {
+              commit("01.01.01: First version", {
                 "src/01.ts": "// v1",
               }),
-              commit("01.01.01 Updated version", {
+              commit("01.01.01: Updated version", {
                 "src/01.ts": "// v2",
               }),
             ])
@@ -303,8 +303,8 @@ describe("cherry-pick (e2e)", () => {
 
           // Test selectLessonCommit directly (without excludeCurrentBranch)
           // to verify the dedup logic with real git log.
-          // git log returns newest-first, and the code takes the last match
-          // (oldest commit), which is the "First version" in this case.
+          // Candidates are ordered oldest -> newest and the code takes the last
+          // match, i.e. the latest commit carrying the id — "Updated version".
           const result = yield* selectLessonCommit({
             branch: "live-run-through",
             lessonId: Option.none(),
@@ -316,9 +316,8 @@ describe("cherry-pick (e2e)", () => {
             ),
           );
 
-          // Code takes matchingCommits[length-1], which is the last in
-          // git log output (oldest). With real git, this is "First version".
-          expect(result.commit.message).toBe("First version");
+          // "Latest wins": the newest commit with this id is selected.
+          expect(result.commit.message).toBe("Updated version");
           expect(result.lessonId).toBe("01.01.01");
         }),
     );
@@ -332,7 +331,7 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -372,15 +371,15 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
-              commit("01.01.02 Arrays advanced", {
+              commit("01.01.02: Arrays advanced", {
                 "src/02.ts": "// arrays advanced",
               }),
             ])
@@ -473,7 +472,7 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -515,10 +514,10 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// original content",
               }),
-              commit("01.01.02 Arrays modified", {
+              commit("01.01.02: Arrays modified", {
                 "src/01.ts": "// modified in lesson",
               }),
             ])
@@ -578,10 +577,10 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
-              commit("01.01.02 Arrays advanced", {
+              commit("01.01.02: Arrays advanced", {
                 "src/02.ts": "// arrays advanced",
               }),
             ])
@@ -627,12 +626,12 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("01.01.01 Main lesson", {
+              commit("01.01.01: Main lesson", {
                 "src/main.ts": "// main",
               }),
             ])
             .withBranch("custom-lessons", [
-              commit("02.01.01 Custom lesson", {
+              commit("02.01.01: Custom lesson", {
                 "src/custom.ts": "// custom content",
               }),
             ])
@@ -687,15 +686,15 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("01.01.01 Main lesson", {
+              commit("01.01.01: Main lesson", {
                 "src/main.ts": "// main",
               }),
             ])
             .withBranch("custom-lessons", [
-              commit("03.01.01 First custom", {
+              commit("03.01.01: First custom", {
                 "src/first.ts": "// first",
               }),
-              commit("03.01.02 Second custom", {
+              commit("03.01.02: Second custom", {
                 "src/second.ts": "// second",
               }),
             ])
@@ -786,15 +785,15 @@ describe("cherry-pick (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
-              commit("01.01.02 Arrays advanced", {
+              commit("01.01.02: Arrays advanced", {
                 "src/02.ts": "// arrays advanced",
               }),
             ])

--- a/test/commit-utils.test.ts
+++ b/test/commit-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  normalizeLessonId,
+  parseCommits,
+} from "../src/commit-utils.js";
+
+describe("parseCommits", () => {
+  it("extracts a slug id as the token before the first ': '", () => {
+    const [c] = parseCommits(
+      "abc123 add-settings-json: Add settings.json"
+    );
+    expect(c!.lessonId).toBe("add-settings-json");
+    expect(c!.message).toBe("Add settings.json");
+  });
+
+  it("treats a numeric id as just another slug token", () => {
+    const [c] = parseCommits("abc123 06.06.01: Arrays intro");
+    expect(c!.lessonId).toBe("06.06.01");
+    expect(c!.message).toBe("Arrays intro");
+  });
+
+  it("returns a null id for a commit with no ': ' boundary", () => {
+    const [c] = parseCommits("abc123 WIP fix stuff later");
+    expect(c!.lessonId).toBeNull();
+    expect(c!.message).toBe("WIP fix stuff later");
+  });
+
+  it("splits on the first ': ' when the title contains more colons", () => {
+    const [c] = parseCommits(
+      "abc123 add-error-handling: Fix: swallow the error"
+    );
+    expect(c!.lessonId).toBe("add-error-handling");
+    expect(c!.message).toBe("Fix: swallow the error");
+  });
+
+  it("parses a conventional-commit prefix as an id — fencing is the range's job, not this parser's", () => {
+    const [c] = parseCommits(
+      "abc123 chore: reconcile pnpm-lock.yaml"
+    );
+    expect(c!.lessonId).toBe("chore");
+  });
+
+  it("does not treat a bare leading ': ' as an id", () => {
+    const [c] = parseCommits("abc123 : orphaned colon");
+    expect(c!.lessonId).toBeNull();
+  });
+});
+
+describe("normalizeLessonId", () => {
+  it("pads a numeric id to NN.NN.NN", () => {
+    expect(normalizeLessonId("1.1.1")).toBe("01.01.01");
+    expect(normalizeLessonId("1-2-3")).toBe("01.02.03");
+  });
+
+  it("returns null for a slug so it passes through untouched", () => {
+    expect(normalizeLessonId("add-settings-json")).toBeNull();
+    expect(normalizeLessonId("chore")).toBeNull();
+  });
+});

--- a/test/reset-e2e.test.ts
+++ b/test/reset-e2e.test.ts
@@ -111,7 +111,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -151,10 +151,10 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays intro",
               }),
-              commit("01.01.02 Arrays solution", {
+              commit("01.01.02: Arrays solution", {
                 "src/01.ts": "// arrays solution",
               }),
             ])
@@ -217,10 +217,10 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays intro",
               }),
-              commit("01.01.02 Arrays continued", {
+              commit("01.01.02: Arrays continued", {
                 "src/01.ts": "// arrays continued",
               }),
             ])
@@ -269,10 +269,10 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays intro",
               }),
-              commit("01.01.02 Arrays solution", {
+              commit("01.01.02: Arrays solution", {
                 "src/01.ts": "// arrays solution",
               }),
             ])
@@ -340,15 +340,15 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
-              commit("01.01.02 Arrays solution", {
+              commit("01.01.02: Arrays solution", {
                 "src/01.ts": "// solution",
               }),
             ])
@@ -415,10 +415,10 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// original",
               }),
-              commit("01.01.02 Arrays solution", {
+              commit("01.01.02: Arrays solution", {
                 "src/01.ts": "// solution",
               }),
             ])
@@ -482,10 +482,10 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// original",
               }),
-              commit("01.01.02 Arrays solution", {
+              commit("01.01.02: Arrays solution", {
                 "src/01.ts": "// solution",
               }),
             ])
@@ -556,10 +556,10 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// problem",
               }),
-              commit("01.01.02 Arrays solution", {
+              commit("01.01.02: Arrays solution", {
                 "src/01.ts": "// solution",
               }),
             ])
@@ -625,7 +625,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -672,7 +672,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays intro",
               }),
             ])
@@ -719,7 +719,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.02.03 Objects intro", {
+              commit("01.02.03: Objects intro", {
                 "src/02.ts": "// objects",
               }),
             ])
@@ -768,7 +768,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -814,12 +814,12 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -875,12 +875,12 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("01.01.01 Main lesson", {
+              commit("01.01.01: Main lesson", {
                 "src/main.ts": "// main",
               }),
             ])
             .withBranch("custom-lessons", [
-              commit("02.01.01 Custom lesson", {
+              commit("02.01.01: Custom lesson", {
                 "src/custom.ts": "// custom content",
               }),
             ])
@@ -941,15 +941,15 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("01.01.01 Main lesson", {
+              commit("01.01.01: Main lesson", {
                 "src/main.ts": "// main",
               }),
             ])
             .withBranch("custom-lessons", [
-              commit("03.01.01 First custom", {
+              commit("03.01.01: First custom", {
                 "src/first.ts": "// first",
               }),
-              commit("03.01.02 Second custom", {
+              commit("03.01.02: Second custom", {
                 "src/second.ts": "// second",
               }),
             ])
@@ -998,7 +998,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.02.03 Some lesson", {
+              commit("01.02.03: Some lesson", {
                 "src/01.ts": "// content",
               }),
             ])
@@ -1038,12 +1038,12 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base setup",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -1099,12 +1099,12 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base setup",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -1148,12 +1148,12 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base setup",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -1214,12 +1214,12 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base setup",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -1271,12 +1271,12 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("main", [
-              commit("00.00.01 Base setup", {
+              commit("00.00.01: Base setup", {
                 "src/base.ts": "// base setup",
               }),
             ])
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -1339,7 +1339,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays intro",
               }),
             ])
@@ -1415,7 +1415,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays intro",
               }),
             ])
@@ -1475,7 +1475,7 @@ describe("reset (e2e)", () => {
           const repo = createTestRepo()
             .withRemote("upstream")
             .withBranch("live-run-through", [
-              commit("01.01.01 Arrays intro", {
+              commit("01.01.01: Arrays intro", {
                 "src/01.ts": "// arrays",
               }),
             ])
@@ -1531,6 +1531,197 @@ describe("reset (e2e)", () => {
             "--list"
           );
           expect(branches).not.toContain("live-run-through");
+        })
+    );
+  });
+
+  describe("slug lesson ids", () => {
+    it.effect(
+      "should reset to the exact commit for a given slug",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("main", [
+              commit("chore: set up tooling", {
+                "src/base.ts": "// base",
+              }),
+            ])
+            .withBranch("live-run-through", [
+              commit("add-arrays: Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+              commit("add-objects: Objects intro", {
+                "src/02.ts": "// objects intro",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          const mockPromptService = fromPartial<PromptService>({
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.some("add-arrays"),
+            demo: false,
+            upstream: getBareRepoPath(repo.workingDir),
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          const content = fs.readFileSync(
+            `${repo.workingDir}/src/01.ts`,
+            "utf-8"
+          );
+          expect(content).toBe("// arrays intro");
+        })
+    );
+
+    it.effect(
+      "should reset to the interactively selected slug",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("main", [
+              commit("chore: set up tooling", {
+                "src/base.ts": "// base",
+              }),
+            ])
+            .withBranch("live-run-through", [
+              commit("add-arrays: Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+              commit("add-objects: Objects solution", {
+                "src/02.ts": "// objects solution",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          const mockPromptService = fromPartial<PromptService>({
+            selectLessonCommit: Effect.fn("selectLessonCommit")(
+              function* () {
+                return "add-objects";
+              }
+            ),
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.none(),
+            demo: false,
+            upstream: getBareRepoPath(repo.workingDir),
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          const content = fs.readFileSync(
+            `${repo.workingDir}/src/02.ts`,
+            "utf-8"
+          );
+          expect(content).toBe("// objects solution");
+        })
+    );
+
+    it.effect(
+      "should exclude conventional-commit base commits on main from the candidate list",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("main", [
+              commit("chore: set up tooling", {
+                "src/base.ts": "// base",
+              }),
+              commit("fix: correct a typo", {
+                "README.md": "# readme",
+              }),
+            ])
+            .withBranch("live-run-through", [
+              commit("add-arrays: Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+              commit("add-objects: Objects intro", {
+                "src/02.ts": "// objects intro",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          let capturedIds: Array<string> = [];
+          const mockPromptService = fromPartial<PromptService>({
+            selectLessonCommit: Effect.fn("selectLessonCommit")(
+              function* (
+                commits: Array<{
+                  lessonId: string;
+                  message: string;
+                }>
+              ) {
+                capturedIds = commits.map((c) => c.lessonId);
+                return "add-arrays";
+              }
+            ),
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.none(),
+            demo: false,
+            upstream: getBareRepoPath(repo.workingDir),
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          // The fence: main's conventional-commit lines never surface as lessons,
+          // and teaching order is commit order (main extra choice, then lessons).
+          expect(capturedIds).not.toContain("chore");
+          expect(capturedIds).not.toContain("fix");
+          expect(capturedIds).toEqual([
+            "main",
+            "add-arrays",
+            "add-objects",
+          ]);
         })
     );
   });


### PR DESCRIPTION
## What

Teaches the `ai-hero` CLI to accept lesson **slugs** in `reset <slug>` and `cherry-pick <slug>`, not just numeric `NN.NN.NN` ids — the migration the `editing-course-repos` skill calls for (repos move from `06.06.01:` numeric prefixes to human-readable slug prefixes).

## Design

- **One generic parser.** A lesson id is now *the token before the first `": "`* in a commit message. A slug (`add-settings-json`), a numeric id (`06.06.01`), and anything else are all just "the token before the colon" — numeric is a subset of slug, no format-specific code path.
- **Structural fence via the lesson stack.** Because any `token: message` prefix is now an id, base and conventional-commit lines (`chore: …`, `fix: …`) could masquerade as lessons. So `selectLessonCommit` scopes its candidate set to `upstream/main..<branch>` — the lesson stack — instead of the branch's full history. That drops every base commit regardless of message shape, with no denylist or slug-shape heuristic. When there's no `upstream/main` to anchor on, it falls back to full-branch history (the base `initial` commit has no `": "` and is filtered out anyway).
- **Teaching order = commit order.** Slugs carry no ordinal, so candidates now list in commit order (oldest→newest) rather than sorted by id. This also aligns duplicate-slug resolution with the "latest wins" contract — the newest matching commit is chosen (previously the oldest, a latent bug the numeric sort masked).
- **Numeric ergonomics preserved.** `normalizeLessonId` stays as a pass-through: `1.1.1` still normalizes to `01.01.01`; slugs pass through untouched.
- **Ephemeral-remote contract honored.** The `upstream/main` fetch happens inside the caller's existing `withUpstreamCleanup` window — no new remote, no new cleanup; the resolved SHA outlives the torn-down remote.

Blast radius is `src/commit-utils.ts` only. `prompt-service` (autocomplete), `branch-commits` (positional, never reads the prefix), and the callers are untouched.

## Known limitation

A non-lesson commit deliberately stacked *inside* `main..<branch>` (e.g. a stray `chore:` reconcile commit — cohort-004 has one) still surfaces as a lesson. The fence removes base commits, not stray commits living on the stack. Documented in the changeset; the fix is repo hygiene, not a heuristic.

## Tests

- New pure unit tests for `parseCommits` / `normalizeLessonId` (colon boundary, numeric-as-subset, conventional-prefix honesty, colon-less → null).
- New slug e2e tests in `reset-e2e`: reset by explicit slug, interactive slug select, and a **regression** that conventional-commit lines on `main` never appear as lessons (asserting exact `["main", "add-arrays", "add-objects"]` order).
- Migrated existing numeric fixtures from the loose space form (`01.01.01 Title`) to the production colon form (`01.01.01: Title`) — real cohort repos use the colon.
- Flipped the "multiple commits with same lesson id" expectation to the newest commit, matching "latest wins".

All 124 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)