### PR TITLE
fix(edit-commit): keep empty commits through the replay

### DIFF
--- a/.changeset/allow-empty-cherry-pick.md
+++ b/.changeset/allow-empty-cherry-pick.md
@@ -1,0 +1,5 @@
+---
+"ai-hero-cli": patch
+---
+
+`internal edit-commit` no longer stalls on empty commits. The replay now cherry-picks with `--allow-empty --keep-redundant-commits`, and the re-authored target commit is created with `--allow-empty`, so empty placeholder commits (slug + subject, no content) are preserved through an edit instead of halting the replay as a conflict with no conflicted files.

--- a/src/git-service/git-service-impl.ts
+++ b/src/git-service/git-service-impl.ts
@@ -200,10 +200,14 @@ export const makeGitService = Effect.gen(function* () {
           yield* runCommandWithExitCode("git", "add", ".");
         }),
 
+        // `--allow-empty` so a commit whose content is unchanged (or which
+        // was an empty placeholder to begin with) still gets re-authored
+        // rather than failing with "nothing to commit".
         commit: Effect.fn("commit")(function* (message: string) {
           const exitCode = yield* runCommandWithExitCode(
             "git",
             "commit",
+            "--allow-empty",
             "-m",
             message
           );
@@ -217,12 +221,20 @@ export const makeGitService = Effect.gen(function* () {
           );
         }),
 
+        // Empty commits are load-bearing in course repos — a placeholder
+        // lesson commit carries a slug and message with no content. Keep
+        // them: `--allow-empty` for commits that started empty,
+        // `--keep-redundant-commits` for ones that become empty on replay.
+        // (The sequencer records both in `.git/sequencer/opts`, so a later
+        // `cherry-pick --continue` inherits them.)
         cherryPick: Effect.fn("cherryPick")(function* (
           range: string
         ) {
           const exitCode = yield* runCommandWithExitCode(
             "git",
             "cherry-pick",
+            "--allow-empty",
+            "--keep-redundant-commits",
             range
           );
 

--- a/test/edit-commit.test.ts
+++ b/test/edit-commit.test.ts
@@ -109,6 +109,26 @@ describe("edit-commit session", () => {
     return repo;
   };
 
+  /**
+   * A course-repo shaped stack: one filled-in lesson followed by empty
+   * placeholder commits that carry only a slug + subject.
+   */
+  const makePlaceholderRepo = () => {
+    const repo = createTestRepo()
+      .withRemote("origin")
+      .withBranch("main", [
+        commit("base", { "base.txt": "base" }),
+      ])
+      .withBranch("live-run-through", [
+        commit("add-first: First", { "a.txt": "first" }),
+        commit("add-second: Second", {}),
+        commit("add-third: Third", {}),
+      ])
+      .build();
+    cleanup = repo.cleanup;
+    return repo;
+  };
+
   const makeConflictingRepo = () => {
     const repo = createTestRepo()
       .withRemote("origin")
@@ -204,6 +224,87 @@ describe("edit-commit session", () => {
         expect(
           git(repo.workingDir, "show", "HEAD:c.txt")
         ).toBe("third");
+      })
+  );
+
+  it.effect(
+    "recompose replays following empty placeholder commits instead of stalling on them",
+    () =>
+      Effect.gen(function* () {
+        const repo = makePlaceholderRepo();
+        const layer = makeLayer(repo.workingDir);
+
+        const session = yield* startSession("add-first").pipe(
+          Effect.provide(layer)
+        );
+
+        fs.writeFileSync(
+          path.join(repo.workingDir, "a.txt"),
+          "first-EDITED"
+        );
+
+        const result = yield* recompose(session).pipe(
+          Effect.provide(layer)
+        );
+        expect(result.conflict).toBe(false);
+
+        // The placeholders survive the replay, in order.
+        const messages = git(
+          repo.workingDir,
+          "log",
+          "--format=%s",
+          "main..HEAD"
+        ).split("\n");
+        expect(messages).toEqual([
+          "add-third: Third",
+          "add-second: Second",
+          "add-first: First",
+        ]);
+
+        // And they're still empty.
+        for (const ref of ["HEAD~1", "HEAD"]) {
+          expect(
+            git(
+              repo.workingDir,
+              "diff",
+              "--name-only",
+              `${ref}^`,
+              ref
+            )
+          ).toBe("");
+        }
+      })
+  );
+
+  it.effect(
+    "recompose re-authors an empty placeholder target the user left empty",
+    () =>
+      Effect.gen(function* () {
+        const repo = makePlaceholderRepo();
+        const layer = makeLayer(repo.workingDir);
+
+        const session = yield* startSession("add-second").pipe(
+          Effect.provide(layer)
+        );
+
+        // The user decides there's nothing to add to this lesson yet, so
+        // the working tree is left exactly as it was found.
+        const result = yield* recompose(session).pipe(
+          Effect.provide(layer)
+        );
+        expect(result.conflict).toBe(false);
+
+        const messages = git(
+          repo.workingDir,
+          "log",
+          "--format=%s",
+          "main..HEAD"
+        ).split("\n");
+        expect(messages).toEqual([
+          "add-third: Third",
+          "add-second: Second",
+          "add-first: First",
+        ]);
       })
   );
 

--- a/test/helpers/create-test-repo.ts
+++ b/test/helpers/create-test-repo.ts
@@ -139,9 +139,14 @@ export const createTestRepo = (): TestRepoBuilder => {
             fs.writeFileSync(fullPath, content);
           }
           git(workDir, "add", ".");
+          // `commit("msg", {})` means an empty placeholder commit —
+          // message only, no content — as used by course repos.
+          const isEmpty =
+            Object.keys(commitDef.files).length === 0;
           git(
             workDir,
             "commit",
+            ...(isEmpty ? ["--allow-empty"] : []),
             "-m",
             commitDef.message
           );


### PR DESCRIPTION
`internal edit-commit continue` stalled on empty commits — the exact shape of the `live-run-through` stack in the crash-course repo, which is a scaffold of empty placeholder commits (slug + message, no content) filled in one lesson at a time.

Two failure points:

- the replay ran `git cherry-pick <range>` with no `--allow-empty`, so an empty placeholder halted the sequencer and got folded into the conflict path — reported as a conflict with **zero** conflicted files, with no way to continue. `--skip` would have silently dropped the placeholder and destroyed its slug (breaking `pnpm reset <slug>`).
- re-authoring the target with `git commit -m` failed with "nothing to commit" when the target was itself an empty placeholder, or when the agent decided not to change anything.

## Change

- `cherryPick` now passes `--allow-empty --keep-redundant-commits`. The sequencer records both in `.git/sequencer/opts`, so a later `cherry-pick --continue` inherits them — `cherryPickContinue` is unchanged (git rejects those flags alongside `--continue`).
- `commit` now passes `--allow-empty`.

## Tests

`createTestRepo`'s `commit("msg", {})` now builds an empty placeholder commit. Two new integration tests against a real repo: replaying past following placeholders (asserting they survive, in order, and stay empty), and re-authoring an empty target the agent left untouched. Both fail on `main` and pass here.

Full suite green: 106 tests, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)