### PR TITLE
feat(internal): add, rename and delete lesson commits

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,19 @@
+---
+"ai-hero-cli": patch
+---
+
+Add `add-commit`, `rename-commit` and `delete-commit` to the `internal` namespace, and open a menu on a bare `internal`.
+
+`internal` was a namespace of one. Editing a lesson's contents was the only history rewrite the CLI could do — creating, renaming or removing a lesson meant dropping to an interactive rebase by hand.
+
+- **`add-commit`** prompts for a slug and a title, composes the `slug: Title` subject, and asks where the lesson goes: at the start, after any existing lesson, or at the end. It commits an empty stub for `edit-commit` to fill in later. Alone among the four it tolerates an empty stack, so it can create a repo's first lesson.
+- **`rename-commit`** changes a lesson's slug and title, each prompt prefilled with the current value. It amends in place, so a rename can never alter a lesson's contents.
+- **`delete-commit`** removes a lesson and replays the rest onto its parent. It shows the diffstat and takes a `backup/` branch before touching anything — it's the only command that destroys authored work rather than moving it.
+
+All three inherit `edit-commit`'s ceremony: a temp branch, the cherry-pick conflict loop that refuses to commit conflict markers, an explicit confirmation before the live branch moves and again before the force-push, and an unwind that restores the repository on cancel.
+
+Slugs are now validated where they're written: kebab-case, no `": "` (the parse boundary), and unique within the stack, since a duplicate silently redirects `reset`.
+
+A bare `ai-hero internal` now opens a menu of the four rather than printing help — outside a TTY it still prints the command list.
+
+Internally, the temp-branch → replay → apply → publish → unwind spine moves into `src/internal/stack/` and all four commands share it, `edit-commit` included. One `unwind` rather than four.

--- a/qa/test-edit-commit.sh
+++ b/qa/test-edit-commit.sh
@@ -2,6 +2,26 @@
 set -e
 
 pnpm run build
-# `internal edit-commit` is interactive: it needs a TTY and prompts for the
-# lesson to edit. Pass `--commit <lesson-id>` to skip the picker.
-(cd ../ralph-tutorial && node ../ai-hero-cli/dist/bin.cjs internal edit-commit)
+
+# Every `internal` command is interactive: each needs a TTY and prompts for the
+# lesson to act on. Pass `--commit <lesson-id>` to skip the picker where the
+# command accepts one (add-commit asks for its insertion point instead).
+#
+# Pass a command name to run just that one, e.g. `./qa/test-edit-commit.sh add`.
+# With no argument you get the menu that a bare `internal` opens.
+COMMAND="${1:-menu}"
+
+case "$COMMAND" in
+  menu)   ARGS="" ;;
+  edit)   ARGS="edit-commit" ;;
+  add)    ARGS="add-commit" ;;
+  rename) ARGS="rename-commit" ;;
+  delete) ARGS="delete-commit" ;;
+  *)
+    echo "Unknown command: $COMMAND (expected menu|edit|add|rename|delete)" >&2
+    exit 1
+    ;;
+esac
+
+# shellcheck disable=SC2086
+(cd ../ralph-tutorial && node ../ai-hero-cli/dist/bin.cjs internal $ARGS)

--- a/src/git-service/git-service-impl.ts
+++ b/src/git-service/git-service-impl.ts
@@ -383,6 +383,67 @@ export const makeGitService = Effect.gen(function* () {
           }
         ),
 
+        // A branch created without checking it out — the backup snapshot
+        // taken before a destructive rewrite, per the maintainer's iron rule.
+        createBranchAt: Effect.fn("createBranchAt")(function* (
+          branchName: string,
+          sha: string
+        ) {
+          const exitCode = yield* runCommandWithExitCode(
+            "git",
+            "branch",
+            branchName,
+            sha
+          );
+
+          yield* mapExitCode(
+            exitCode,
+            (code) =>
+              new FailedToCreateBranchError({
+                branchName,
+                message: `Failed to create branch ${branchName} at ${sha} (exit code: ${code})`,
+              })
+          );
+        }),
+
+        // Re-author HEAD's subject without touching its tree. `--allow-empty`
+        // because a placeholder lesson commit carries no content and must
+        // survive being renamed.
+        amendCommitMessage: Effect.fn("amendCommitMessage")(
+          function* (message: string) {
+            const exitCode = yield* runCommandWithExitCode(
+              "git",
+              "commit",
+              "--amend",
+              "--allow-empty",
+              "-m",
+              message
+            );
+
+            yield* mapExitCode(
+              exitCode,
+              (code) =>
+                new FailedToCommitError({
+                  message: `Failed to amend commit message (exit code: ${code})`,
+                })
+            );
+          }
+        ),
+
+        /** A commit's diffstat, for showing what a delete would destroy. */
+        showStat: Effect.fn("showStat")(function* (
+          sha: string
+        ) {
+          return yield* runCommandWithString(
+            "git",
+            "show",
+            "--stat",
+            "--format=%s",
+            "--no-color",
+            sha
+          );
+        }),
+
         deleteBranch: Effect.fn("deleteBranch")(function* (
           branchName: string
         ) {

--- a/src/internal/add-commit/command.ts
+++ b/src/internal/add-commit/command.ts
@@ -1,0 +1,129 @@
+import { Command as CLICommand } from "@effect/cli";
+import { Console, Effect } from "effect";
+import {
+  type BranchCommit,
+  CommitNotFoundError,
+  resolveCommitRef,
+} from "../../branch-commits.js";
+import { PromptService } from "../../prompt-service.js";
+import { runCeremony } from "../stack/ceremony.js";
+import {
+  branchOption,
+  mainBranchOption,
+  reportErrors,
+  requireInteractiveRepo,
+} from "../stack/options.js";
+import { loadCommitsAllowingEmpty } from "../stack/session.js";
+import { promptForSubject } from "../stack/slug.js";
+import {
+  beginAddSession,
+  composeStub,
+  type InsertPosition,
+} from "./session.js";
+
+export interface AddCommitOptions {
+  branch: string;
+  mainBranch: string;
+}
+
+/** Ask where the new lesson goes, skipping the question on an empty stack. */
+const askPosition = (commits: Array<BranchCommit>) =>
+  Effect.gen(function* () {
+    const prompts = yield* PromptService;
+
+    const lessons = commits.filter(
+      (commit) => commit.lessonId !== null
+    );
+
+    // Nothing to insert between — the first lesson can only go at the tip.
+    if (lessons.length === 0) {
+      return { _tag: "end" } satisfies InsertPosition;
+    }
+
+    const choice = yield* prompts.selectInsertPosition(
+      lessons.map((commit) => ({
+        lessonId: commit.lessonId!,
+        message: commit.description,
+      }))
+    );
+
+    if (choice._tag !== "after") {
+      return choice satisfies InsertPosition;
+    }
+
+    const commit = resolveCommitRef(lessons, choice.lessonId);
+    // The picker can only return an id we offered, so a miss means the list
+    // and the resolver disagree — fail loudly rather than insert blind.
+    if (!commit) {
+      return yield* new CommitNotFoundError({
+        commit: choice.lessonId,
+      });
+    }
+
+    return {
+      _tag: "after",
+      commit,
+    } satisfies InsertPosition;
+  });
+
+/**
+ * Add an empty stub lesson to the stack, to be filled in later with
+ * `edit-commit`.
+ *
+ * Alone among the internal commands this tolerates an empty stack: "there are
+ * no lessons yet" is a perfectly good state to be adding the first one from.
+ */
+export const runAddCommit = (opts: AddCommitOptions) =>
+  Effect.gen(function* () {
+    const liveBranch = opts.branch;
+
+    yield* requireInteractiveRepo("add-commit");
+
+    const commits = yield* loadCommitsAllowingEmpty({
+      branch: liveBranch,
+      mainBranch: opts.mainBranch,
+    });
+
+    // Everything that can fail or be cancelled happens before a branch moves.
+    const { slug, subject } = yield* promptForSubject({ commits });
+    const position = yield* askPosition(commits);
+
+    const session = yield* beginAddSession({
+      commits,
+      position,
+      liveBranch,
+    });
+
+    yield* runCeremony({
+      session,
+      label: slug,
+      verb: "added",
+      compose: Effect.gen(function* () {
+        yield* Console.log(
+          `\nAdding "${subject}" on ${session.tempBranch}`
+        );
+        yield* Console.log(
+          session.following === 0
+            ? "It goes at the end of the stack; nothing needs replaying."
+            : `Will replay ${session.following} commit${
+                session.following === 1 ? "" : "s"
+              } after it.`
+        );
+
+        return yield* composeStub({ session, subject });
+      }),
+    });
+  }).pipe(reportErrors);
+
+export const addCommit = CLICommand.make(
+  "add-commit",
+  {
+    branch: branchOption,
+    mainBranch: mainBranchOption,
+  },
+  runAddCommit
+).pipe(
+  CLICommand.withDescription(
+    "Add an empty stub lesson commit to fill in later"
+  )
+);

--- a/src/internal/add-commit/session.ts
+++ b/src/internal/add-commit/session.ts
@@ -1,0 +1,109 @@
+import { Effect } from "effect";
+import type { BranchCommit } from "../../branch-commits.js";
+import { GitService } from "../../git-service.js";
+import {
+  beginStackSession,
+  replayFollowing,
+  type StackSession,
+} from "../stack/session.js";
+
+/**
+ * Where a new lesson goes in the stack. Resolved from the picker before any
+ * branch moves, so a bad position can't strand a temp branch.
+ */
+export type InsertPosition =
+  | { _tag: "start" }
+  | { _tag: "end" }
+  | { _tag: "after"; commit: BranchCommit };
+
+/**
+ * The base sha a new lesson's temp branch starts from.
+ *
+ * "At the start" is just "insert after the first lesson's parent" — no
+ * special case beyond asking git for that parent.
+ */
+const resolveBase = (opts: {
+  position: InsertPosition;
+  commits: Array<BranchCommit>;
+  liveBranch: string;
+}) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    switch (opts.position._tag) {
+      case "end":
+        return yield* git.revParse(opts.liveBranch);
+      case "after":
+        return opts.position.commit.sha;
+      case "start": {
+        const first = opts.commits[0];
+        // An empty stack has no first lesson, so "the start" *is* the tip.
+        if (!first) {
+          return yield* git.revParse(opts.liveBranch);
+        }
+        return yield* git.revParse(`${first.sha}^`);
+      }
+    }
+  });
+
+/** How many commits will need replaying after inserting at `position`. */
+const countFollowing = (opts: {
+  position: InsertPosition;
+  commits: Array<BranchCommit>;
+}) => {
+  switch (opts.position._tag) {
+    case "end":
+      return 0;
+    case "start":
+      return opts.commits.length;
+    case "after":
+      return opts.commits.length - opts.position.commit.sequence;
+  }
+};
+
+/**
+ * Open a session with the temp branch parked where the new lesson belongs.
+ *
+ * `replayFrom` is the same sha as the base: everything after the insertion
+ * point gets replayed on top of the new stub.
+ */
+export const beginAddSession = (opts: {
+  commits: Array<BranchCommit>;
+  position: InsertPosition;
+  liveBranch: string;
+}) =>
+  Effect.gen(function* () {
+    const base = yield* resolveBase({
+      position: opts.position,
+      commits: opts.commits,
+      liveBranch: opts.liveBranch,
+    });
+
+    return yield* beginStackSession({
+      liveBranch: opts.liveBranch,
+      base,
+      following: countFollowing({
+        position: opts.position,
+        commits: opts.commits,
+      }),
+      operation: "add-commit",
+    });
+  });
+
+/**
+ * Commit the empty stub, then replay everything that followed the insertion
+ * point. The stub carries a subject and no content — `edit-commit` fills it
+ * in later, and the empty commit survives every subsequent replay because
+ * `cherryPick` keeps redundant commits.
+ */
+export const composeStub = (opts: {
+  session: StackSession;
+  subject: string;
+}) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    yield* git.commit(opts.subject);
+
+    return yield* replayFollowing(opts.session);
+  });

--- a/src/internal/delete-commit/command.ts
+++ b/src/internal/delete-commit/command.ts
@@ -1,0 +1,108 @@
+import { Command as CLICommand } from "@effect/cli";
+import type { Option } from "effect";
+import { Console, Effect } from "effect";
+import { GitService } from "../../git-service.js";
+import { PromptService } from "../../prompt-service.js";
+import { runCeremony } from "../stack/ceremony.js";
+import {
+  branchOption,
+  commitOption,
+  mainBranchOption,
+  reportErrors,
+  requireInteractiveRepo,
+} from "../stack/options.js";
+import { loadCommits } from "../stack/session.js";
+import { labelOf, resolveTarget } from "../stack/target.js";
+import {
+  beginDeleteSession,
+  replayWithoutTarget,
+} from "./session.js";
+
+export interface DeleteCommitOptions {
+  commit: Option.Option<string>;
+  branch: string;
+  mainBranch: string;
+}
+
+/**
+ * Remove a lesson from the history entirely.
+ *
+ * The extra up-front confirmation and the diffstat are deliberate: this is the
+ * only internal command that destroys authored work rather than moving it, and
+ * the diffstat is what tells you at a glance whether later lessons build on
+ * what you're about to drop. A conflict during the replay usually means
+ * exactly that — the tool working, not failing.
+ */
+export const runDeleteCommit = (opts: DeleteCommitOptions) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+    const prompts = yield* PromptService;
+    const liveBranch = opts.branch;
+
+    yield* requireInteractiveRepo("delete-commit");
+
+    const commits = yield* loadCommits({
+      branch: liveBranch,
+      mainBranch: opts.mainBranch,
+    });
+
+    const target = yield* resolveTarget({
+      commits,
+      commit: opts.commit,
+      promptMessage:
+        "Which lesson do you want to delete? (type to search)",
+    });
+
+    const label = labelOf(target);
+    const following = commits.length - target.sequence;
+
+    yield* Console.log(`\n${target.message}`);
+    yield* Console.log(yield* git.showStat(target.sha));
+
+    yield* prompts.confirmDeleteLesson({ label, following });
+
+    const session = yield* beginDeleteSession({
+      commits,
+      target,
+      liveBranch,
+    });
+
+    yield* runCeremony({
+      session,
+      label,
+      verb: "deleted",
+      compose: Effect.gen(function* () {
+        yield* Console.log(
+          `\nDeleting ${label} on ${session.tempBranch}`
+        );
+        if (session.backupBranch) {
+          yield* Console.log(
+            `Backed up the previous history to ${session.backupBranch}`
+          );
+        }
+        yield* Console.log(
+          session.following === 0
+            ? `No commits follow ${label}.`
+            : `Will replay ${session.following} commit${
+                session.following === 1 ? "" : "s"
+              } after it.`
+        );
+
+        return yield* replayWithoutTarget(session);
+      }),
+    });
+  }).pipe(reportErrors);
+
+export const deleteCommit = CLICommand.make(
+  "delete-commit",
+  {
+    commit: commitOption,
+    branch: branchOption,
+    mainBranch: mainBranchOption,
+  },
+  runDeleteCommit
+).pipe(
+  CLICommand.withDescription(
+    "Remove a lesson commit from the history"
+  )
+);

--- a/src/internal/delete-commit/session.ts
+++ b/src/internal/delete-commit/session.ts
@@ -1,0 +1,48 @@
+import { Effect } from "effect";
+import type { BranchCommit } from "../../branch-commits.js";
+import { GitService } from "../../git-service.js";
+import {
+  beginStackSession,
+  replayFollowing,
+  type StackSession,
+} from "../stack/session.js";
+
+/**
+ * Open a session with the temp branch parked on the target's **parent**, while
+ * still replaying from the target itself.
+ *
+ * That gap between base and `replayFrom` is the whole deletion: the range
+ * `target..head` covers the commits *after* the target, so replaying it onto
+ * the target's parent reconstructs the stack without it.
+ *
+ * Takes a backup branch first — this is the one operation that destroys
+ * authored work rather than moving it.
+ */
+export const beginDeleteSession = (opts: {
+  commits: Array<BranchCommit>;
+  target: BranchCommit;
+  liveBranch: string;
+}) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    const parent = yield* git.revParse(`${opts.target.sha}^`);
+
+    return yield* beginStackSession({
+      liveBranch: opts.liveBranch,
+      base: parent,
+      replayFrom: opts.target.sha,
+      following: opts.commits.length - opts.target.sequence,
+      operation: "delete-commit",
+      backup: true,
+    });
+  });
+
+/**
+ * Replay the commits that followed the deleted one.
+ *
+ * There is no "compose" step — the temp branch already sits at the parent, so
+ * the deletion has happened simply by not replaying the target.
+ */
+export const replayWithoutTarget = (session: StackSession) =>
+  replayFollowing(session);

--- a/src/internal/edit-commit/command.ts
+++ b/src/internal/edit-commit/command.ts
@@ -1,158 +1,61 @@
-import { Command as CLICommand, Options } from "@effect/cli";
-import { Console, Data, Effect, Option } from "effect";
-import { existsSync } from "node:fs";
-import * as path from "node:path";
-import {
-  CommitNotFoundError,
-  resolveCommitRef,
-  selectCommit,
-} from "../../branch-commits.js";
-import { DEFAULT_PROJECT_TARGET_BRANCH } from "../../constants.js";
+import { Command as CLICommand } from "@effect/cli";
+import type { Option } from "effect";
+import { Console, Effect } from "effect";
 import { PromptService } from "../../prompt-service.js";
+import { runCeremony } from "../stack/ceremony.js";
 import {
-  applyToLiveBranch,
-  beginSession,
-  conflictedFiles,
-  filesWithMarkers,
-  finish,
-  loadCommits,
-  NotAGitRepoError,
-  publish,
-  recompose,
-  resumeCherryPick,
-  unwind,
-} from "./session.js";
+  branchOption,
+  commitOption,
+  mainBranchOption,
+  reportErrors,
+  requireInteractiveRepo,
+} from "../stack/options.js";
+import { labelOf, resolveTarget } from "../stack/target.js";
+import { beginSession, loadCommits, recompose } from "./session.js";
 
-export class NotATtyError extends Data.TaggedError(
-  "NotATtyError"
-) {}
+export interface EditCommitOptions {
+  commit: Option.Option<string>;
+  branch: string;
+  mainBranch: string;
+}
 
 /**
- * The stage the session has reached, which decides how a cancellation unwinds.
+ * Interactively edit a lesson commit's contents.
  *
- *   editing  -> the target's diff is in the working tree, uncommitted.
- *   conflict -> a cherry-pick has stopped; resolved files are uncommitted.
- *   composed -> everything is committed on the temp branch.
- *   applied  -> the live branch has been moved onto the temp branch.
+ * Exported as a plain function so both the CLI subcommand and the `internal`
+ * picker run exactly one implementation.
  */
-type Stage = "editing" | "conflict" | "composed" | "applied";
+export const runEditCommit = (opts: EditCommitOptions) =>
+  Effect.gen(function* () {
+    const prompts = yield* PromptService;
+    const liveBranch = opts.branch;
 
-const commitOption = Options.text("commit").pipe(
-  Options.withAlias("c"),
-  Options.withDescription(
-    "Lesson to edit: a lesson id (slug or numeric) or a SHA prefix. Omit to pick from a list."
-  ),
-  Options.optional
-);
+    yield* requireInteractiveRepo("edit-commit");
 
-const branchOption = Options.text("branch").pipe(
-  Options.withDescription("The live branch holding the commits"),
-  Options.withDefault(DEFAULT_PROJECT_TARGET_BRANCH)
-);
+    const commits = yield* loadCommits({
+      branch: liveBranch,
+      mainBranch: opts.mainBranch,
+    });
 
-const mainBranchOption = Options.text("main-branch").pipe(
-  Options.withDescription("The base branch of the project"),
-  Options.withDefault("main")
-);
+    const target = yield* resolveTarget({
+      commits,
+      commit: opts.commit,
+      promptMessage:
+        "Which lesson do you want to edit? (type to search)",
+    });
 
-/**
- * Walk the cherry-pick conflict loop until it clears or the user aborts.
- * Returns false when the user chose to abort the whole session.
- *
- * Written as a loop rather than a recursive effect so the error and
- * requirement channels stay inferred.
- */
-const resolveConflicts = Effect.gen(function* () {
-  const prompts = yield* PromptService;
+    const label = labelOf(target);
+    const session = yield* beginSession({
+      commits,
+      target,
+      liveBranch,
+    });
 
-  while (true) {
-    const files = yield* conflictedFiles;
-    yield* Console.log("\n⚠️  Cherry-pick conflict:");
-    for (const file of files) {
-      yield* Console.log(`   ${file}`);
-    }
-
-    const action =
-      yield* prompts.selectCherryPickConflictAction();
-
-    if (action === "abort") {
-      return false;
-    }
-
-    // Never take "continue" on trust — a committed `<<<<<<<` surfaces later as
-    // a broken exercise for students rather than immediately for the author.
-    const stillMarked = yield* filesWithMarkers;
-    if (stillMarked.length > 0) {
-      yield* Console.log(
-        "\nThese files still contain conflict markers:"
-      );
-      for (const file of stillMarked) {
-        yield* Console.log(`   ${file}`);
-      }
-      continue;
-    }
-
-    const result = yield* resumeCherryPick;
-    if (result.conflict) {
-      continue;
-    }
-
-    yield* Console.log("✓ Cherry-pick complete");
-    return true;
-  }
-});
-
-export const editCommit = CLICommand.make(
-  "edit-commit",
-  {
-    commit: commitOption,
-    branch: branchOption,
-    mainBranch: mainBranchOption,
-  },
-  ({ branch: liveBranch, commit, mainBranch }) =>
-    Effect.gen(function* () {
-      const cwd = process.cwd();
-      const prompts = yield* PromptService;
-
-      if (!existsSync(path.join(cwd, ".git"))) {
-        return yield* new NotAGitRepoError({ path: cwd });
-      }
-
-      // This command is interactive by design. Rather than silently degrading
-      // into a non-interactive mode, refuse — a caller without a TTY is
-      // reaching for something this command no longer offers.
-      if (!process.stdin.isTTY || !process.stdout.isTTY) {
-        return yield* new NotATtyError();
-      }
-
-      const commits = yield* loadCommits({
-        branch: liveBranch,
-        mainBranch,
-      });
-
-      // Resolve the target before touching any branch, so a bad reference
-      // can't strand a temp branch.
-      const target = Option.isSome(commit)
-        ? (resolveCommitRef(commits, commit.value) ??
-          (yield* new CommitNotFoundError({
-            commit: commit.value,
-          })))
-        : yield* selectCommit({
-            commits,
-            promptMessage:
-              "Which lesson do you want to edit? (type to search)",
-          });
-
-      const label = target.lessonId ?? target.sha;
-      const session = yield* beginSession({
-        commits,
-        target,
-        liveBranch,
-      });
-
-      let stage: Stage = "editing";
-
-      const body = Effect.gen(function* () {
+    yield* runCeremony({
+      session,
+      label,
+      verb: "updated",
+      compose: Effect.gen(function* () {
         yield* Console.log(
           `Editing ${label} on ${session.tempBranch}`
         );
@@ -172,139 +75,19 @@ export const editCommit = CLICommand.make(
         yield* Console.log(
           `Committing with original message: "${session.target.message}"`
         );
-        const result = yield* recompose(session);
-
-        if (result.conflict) {
-          stage = "conflict";
-          const resolved = yield* resolveConflicts;
-          if (!resolved) {
-            yield* Console.log("Aborting session…");
-            const { discardedFiles } = yield* unwind(session, {
-              midCherryPick: true,
-              liveBranchMoved: false,
-              keepTempBranch: false,
-            });
-            yield* Console.log(
-              `✓ Restored ${session.originalBranch}; discarded ${discardedFiles.length} path(s)`
-            );
-            return;
-          }
-        }
-
-        stage = "composed";
-        yield* Console.log(`\n✓ ${label} updated`);
-
-        yield* prompts.confirmSaveToTargetBranch(liveBranch);
-        yield* applyToLiveBranch(session);
-        stage = "applied";
-        yield* Console.log(
-          `✓ ${liveBranch} updated with your changes`
-        );
-
-        yield* prompts.confirmForcePush(liveBranch);
-        yield* publish(session);
-        yield* Console.log(
-          `✓ Pushed ${liveBranch} to origin`
-        );
-
-        yield* finish(session);
-        yield* Console.log(
-          `✓ Switched back to ${session.originalBranch}`
-        );
-      });
-
-      /**
-       * Cancelling a prompt unwinds in-process. Before the edits are committed
-       * we ask first, because the unwind throws away hand-written work; once
-       * they're committed we unwind silently but keep the temp branch, so
-       * backing out of a push never costs you the edit.
-       */
-      const onCancel = Effect.gen(function* () {
-        if (stage === "editing" || stage === "conflict") {
-          const discard = yield* prompts.confirmDiscardChanges(
-            session.tempBranch
-          );
-
-          if (!discard) {
-            yield* Console.log(
-              `Cancelled. Your changes are on ${session.tempBranch}.`
-            );
-            return;
-          }
-
-          const { discardedFiles } = yield* unwind(session, {
-            midCherryPick: stage === "conflict",
-            liveBranchMoved: false,
-            keepTempBranch: false,
-          });
-          yield* Console.log(
-            `✓ Restored ${session.originalBranch}; discarded ${discardedFiles.length} path(s)`
-          );
-          return;
-        }
-
-        yield* unwind(session, {
-          midCherryPick: false,
-          liveBranchMoved: stage === "applied",
-          keepTempBranch: true,
-        });
-        yield* Console.log(
-          `Cancelled. Your recomposed branch is ${session.tempBranch}.`
-        );
-      });
-
-      yield* body.pipe(
-        Effect.catchTag("PromptCancelledError", () => onCancel),
-        // A hard interrupt can't prompt, so leave everything alone and print
-        // the breadcrumb needed to find the work again.
-        Effect.onInterrupt(() =>
-          Console.log(
-            `\nInterrupted. Your session is on ${session.tempBranch}.`
-          )
-        )
-      );
-    }).pipe(
-      Effect.catchTags({
-        NotAGitRepoError: (error) =>
-          Effect.gen(function* () {
-            yield* Console.error(
-              `Error: not a git repository: ${error.path}`
-            );
-            process.exitCode = 1;
-          }),
-        NotATtyError: () =>
-          Effect.gen(function* () {
-            yield* Console.error(
-              "Error: `edit-commit` is interactive and needs a TTY."
-            );
-            process.exitCode = 1;
-          }),
-        NoCommitsFoundError: (error) =>
-          Effect.gen(function* () {
-            yield* Console.error(
-              `Error: No commits found on ${error.liveBranch} beyond ${error.mainBranch}`
-            );
-            process.exitCode = 1;
-          }),
-        CommitNotFoundError: (error) =>
-          Effect.gen(function* () {
-            yield* Console.error(
-              `Error: No lesson matching "${error.commit}"`
-            );
-            process.exitCode = 1;
-          }),
-        PromptCancelledError: () =>
-          Effect.gen(function* () {
-            yield* Console.log("Cancelled.");
-          }),
+        return yield* recompose(session);
       }),
-      Effect.catchAll((error) =>
-        Effect.gen(function* () {
-          yield* Console.error(`Unexpected error: ${error}`);
-          process.exitCode = 1;
-        })
-      )
-    )
+    });
+  }).pipe(reportErrors);
+
+export const editCommit = CLICommand.make(
+  "edit-commit",
+  {
+    commit: commitOption,
+    branch: branchOption,
+    mainBranch: mainBranchOption,
+  },
+  runEditCommit
 ).pipe(
   CLICommand.withDescription(
     "Interactively edit a lesson commit and replay the commits after it"

--- a/src/internal/edit-commit/session.ts
+++ b/src/internal/edit-commit/session.ts
@@ -1,49 +1,35 @@
-import { FileSystem } from "@effect/platform";
-import { Data, Effect } from "effect";
-import * as path from "node:path";
+import { Effect } from "effect";
 import type { BranchCommit } from "../../branch-commits.js";
-import { getCommitsBetweenBranches } from "../../branch-commits.js";
-import type { PlatformError } from "@effect/platform/Error";
-import type { CherryPickConflictError } from "../../git-service/errors.js";
-import { GitService, GitServiceConfig } from "../../git-service.js";
-
-export class NotAGitRepoError extends Data.TaggedError(
-  "NotAGitRepoError"
-)<{
-  path: string;
-}> {}
+import { GitService } from "../../git-service.js";
+import {
+  beginStackSession,
+  replayFollowing,
+  type StackSession,
+} from "../stack/session.js";
 
 /**
- * A live edit-commit session. Everything needed to unwind or complete the
- * session is held here, in one process — deliberately not persisted. A session
- * that outlives its process is not resumable; see the changeset.
+ * Edit-commit's session: the shared stack spine plus the commit being edited.
+ *
+ * The spine itself lives in `../stack/session.ts` and is shared with add,
+ * rename and delete. Only the middle — parking the target's diff in the
+ * working tree, then re-authoring it — is specific to editing.
  */
-export interface EditSession {
-  tempBranch: string;
-  originalBranch: string;
-  liveBranch: string;
+export interface EditSession extends StackSession {
   target: BranchCommit;
-  /** Live branch tip before the session began — what we cherry-pick up to. */
-  targetBranchHead: string;
-  /** Number of commits following the target on the live branch. */
-  following: number;
 }
 
-/** Fetch origin and read the lesson stack, oldest first. */
-export const loadCommits = (opts: {
-  branch: string;
-  mainBranch: string;
-}) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
-
-    yield* git.fetchOrigin();
-
-    return yield* getCommitsBetweenBranches({
-      mainBranch: opts.mainBranch,
-      liveBranch: opts.branch,
-    });
-  });
+export {
+  applyToLiveBranch,
+  conflictedFiles,
+  filesWithMarkers,
+  finish,
+  loadCommits,
+  NotAGitRepoError,
+  publish,
+  resumeCherryPick,
+  unwind,
+  type UnwindOptions,
+} from "../stack/session.js";
 
 /**
  * Park the target commit's diff in the working tree on a fresh temp branch.
@@ -59,89 +45,21 @@ export const beginSession = (opts: {
   Effect.gen(function* () {
     const git = yield* GitService;
 
-    const following = opts.commits.length - opts.target.sequence;
-    const targetBranchHead = yield* git.revParse(opts.liveBranch);
-    const originalBranch = yield* git.getCurrentBranch();
+    const session = yield* beginStackSession({
+      liveBranch: opts.liveBranch,
+      base: opts.target.sha,
+      following: opts.commits.length - opts.target.sequence,
+      operation: "edit-commit",
+    });
 
-    const tempBranch = `matt/edit-commit-${Date.now()}`;
-    yield* git.checkoutNewBranch(tempBranch);
+    // Rewind onto the target's parent, leaving its diff unstaged for editing.
     yield* git.applyAsUnstagedChanges(opts.target.sha);
 
     return {
-      tempBranch,
-      originalBranch,
-      liveBranch: opts.liveBranch,
+      ...session,
       target: opts.target,
-      targetBranchHead,
-      following,
     } satisfies EditSession;
   });
-
-/** All changed paths parsed from `git status --short`. */
-const parseStatusPaths = (status: string) =>
-  status
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => ({
-      xy: line.slice(0, 2),
-      path: line.slice(3).trim(),
-    }));
-
-/** Files with unmerged paths, parsed from `git status --short`. */
-export const conflictedFiles = Effect.gen(function* () {
-  const git = yield* GitService;
-  const status = yield* git.getStatusShort();
-  return parseStatusPaths(status)
-    .filter(
-      ({ xy }) => xy.includes("U") || xy === "AA" || xy === "DD"
-    )
-    .map((entry) => entry.path);
-});
-
-/**
- * Of the currently-unmerged files, those that still contain conflict markers.
- *
- * The point of actually reading the files: "continue" must not take the user's
- * word for it and commit `<<<<<<<` into a lesson, where it surfaces later as a
- * broken exercise for students rather than immediately for the author.
- */
-export const filesWithMarkers = Effect.gen(function* () {
-  const fs = yield* FileSystem.FileSystem;
-  const { cwd } = yield* GitServiceConfig;
-  const unmerged = yield* conflictedFiles;
-
-  const remaining: Array<string> = [];
-  for (const file of unmerged) {
-    const content = yield* fs.readFileString(
-      path.join(cwd, file)
-    );
-    if (
-      content.includes("<<<<<<<") ||
-      content.includes(">>>>>>>")
-    ) {
-      remaining.push(file);
-    }
-  }
-  return remaining;
-});
-
-/**
- * Run a cherry-pick effect and report whether it stopped on a conflict,
- * folding the typed conflict error into a plain boolean result.
- */
-const detectConflict = <A, R>(
-  effect: Effect.Effect<
-    A,
-    CherryPickConflictError | PlatformError,
-    R
-  >
-) =>
-  effect.pipe(
-    Effect.map(() => ({ conflict: false as const })),
-    Effect.catchTag("CherryPickConflictError", () =>
-      Effect.succeed({ conflict: true as const })
-    )
-  );
 
 /**
  * Re-author the target commit from the working tree, then replay the commits
@@ -153,106 +71,8 @@ export const recompose = (session: EditSession) =>
 
     yield* git.stageAll();
     // The original subject is reused verbatim — editing a lesson's contents
-    // must never silently rename the lesson.
+    // must never silently rename the lesson. Renaming is `rename-commit`.
     yield* git.commit(session.target.message);
 
-    if (session.following === 0) {
-      return { conflict: false as const };
-    }
-
-    return yield* detectConflict(
-      git.cherryPick(
-        `${session.target.sha}..${session.targetBranchHead}`
-      )
-    );
-  });
-
-/** Resume a conflicted cherry-pick from the resolved working tree. */
-export const resumeCherryPick = Effect.gen(function* () {
-  const git = yield* GitService;
-  yield* git.stageAll();
-  return yield* detectConflict(git.cherryPickContinue());
-});
-
-/** Move the live branch onto the recomposed temp branch. */
-export const applyToLiveBranch = (session: EditSession) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
-    yield* git.checkout(session.liveBranch);
-    yield* git.resetHard(session.tempBranch);
-  });
-
-/** Force-push the recomposed live branch to origin. */
-export const publish = (session: EditSession) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
-    yield* git.pushForceWithLease("origin", session.liveBranch);
-  });
-
-/** Return to the branch we started on and drop the temp branch. */
-export const finish = (session: EditSession) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
-    yield* git.checkout(session.originalBranch);
-    yield* git.deleteBranch(session.tempBranch);
-  });
-
-export interface UnwindOptions {
-  /** A cherry-pick is mid-flight and must be aborted first. */
-  midCherryPick: boolean;
-  /** The live branch has already been moved onto the temp branch. */
-  liveBranchMoved: boolean;
-  /**
-   * Leave the temp branch in place rather than deleting it. Used once the
-   * user's edits are committed: backing out of publishing shouldn't throw the
-   * edits away, so we restore every *other* branch and hand back the name.
-   */
-  keepTempBranch: boolean;
-}
-
-/**
- * Tear the session down and restore the repository to how we found it.
- *
- * This is the fix for the old command's worst behaviour: cancelling a prompt
- * printed "Branch left as-is" and abandoned a `matt/edit-commit-*` branch that
- * nothing could later find. Returns the working-tree paths it discarded.
- */
-export const unwind = (
-  session: EditSession,
-  opts: UnwindOptions
-) =>
-  Effect.gen(function* () {
-    const git = yield* GitService;
-
-    const discardedFiles = opts.keepTempBranch
-      ? []
-      : parseStatusPaths(yield* git.getStatusShort()).map(
-          (entry) => entry.path
-        );
-
-    if (opts.midCherryPick) {
-      yield* git.cherryPickAbort();
-    }
-
-    if (!opts.keepTempBranch && !opts.liveBranchMoved) {
-      // Still parked on the temp branch with a dirty tree — clear it so the
-      // checkout below can't be blocked by uncommitted changes.
-      yield* git.resetHard(session.tempBranch);
-      yield* git.clean();
-    }
-
-    if (opts.liveBranchMoved) {
-      // The live branch was already reset onto the temp branch; put it back
-      // where it was before the session started.
-      yield* git.checkout(session.liveBranch);
-      yield* git.resetHard(session.targetBranchHead);
-    }
-
-    yield* git.checkout(session.originalBranch);
-
-    if (!opts.keepTempBranch) {
-      yield* git.deleteBranch(session.tempBranch);
-    }
-
-    return { discardedFiles };
+    return yield* replayFollowing(session);
   });

--- a/src/internal/internal.ts
+++ b/src/internal/internal.ts
@@ -1,7 +1,99 @@
 import { Command as CLICommand } from "@effect/cli";
-import { editCommit } from "./edit-commit/command.js";
+import { Console, Effect, Option } from "effect";
+import { PromptService } from "../prompt-service.js";
+import { addCommit, runAddCommit } from "./add-commit/command.js";
+import {
+  deleteCommit,
+  runDeleteCommit,
+} from "./delete-commit/command.js";
+import { editCommit, runEditCommit } from "./edit-commit/command.js";
+import {
+  renameCommit,
+  runRenameCommit,
+} from "./rename-commit/command.js";
+import {
+  branchOption,
+  mainBranchOption,
+  reportErrors,
+} from "./stack/options.js";
 
-export const internal = CLICommand.make("internal").pipe(
-  CLICommand.withSubcommands([editCommit]),
-  CLICommand.withDescription("Internal commands for AI Hero"),
+/**
+ * A bare `internal` opens a menu of the four commands.
+ *
+ * `@effect/cli` runs a parent's own handler when it is invoked without a
+ * subcommand, so this costs no restructuring — naming a subcommand still
+ * dispatches straight to it.
+ *
+ * The picker calls the same exported `run*` functions the subcommands do, so
+ * there is exactly one implementation of each and the picker never re-enters
+ * the argument parser.
+ */
+const runInternalPicker = (opts: {
+  branch: string;
+  mainBranch: string;
+}) =>
+  Effect.gen(function* () {
+    // The menu is the entry point, so a caller with no TTY has most likely
+    // just typed the wrong thing. Show them what's here rather than refusing —
+    // and printing help is what bare `internal` did before the menu existed.
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      yield* Console.log(
+        [
+          "Internal commands for AI Hero:",
+          "",
+          "  edit-commit     Edit a lesson's contents and replay the commits after it",
+          "  add-commit      Add an empty stub lesson to fill in later",
+          "  rename-commit   Change a lesson's slug and title",
+          "  delete-commit   Remove a lesson from the history entirely",
+          "",
+          "Run `ai-hero internal <command> --help` for details.",
+          "Run `ai-hero internal` in a terminal to pick from a menu.",
+        ].join("\n")
+      );
+      return;
+    }
+
+    const prompts = yield* PromptService;
+    const choice = yield* prompts.selectInternalCommand();
+
+    // `--commit` is deliberately not hoisted onto the menu: picking the lesson
+    // interactively is the whole point of arriving here.
+    const shared = {
+      commit: Option.none<string>(),
+      branch: opts.branch,
+      mainBranch: opts.mainBranch,
+    };
+
+    // One command, then exit. Looping back would invite a second rewrite
+    // against a repo state that has just been force-pushed and not re-read.
+    switch (choice) {
+      case "edit-commit":
+        return yield* runEditCommit(shared);
+      case "add-commit":
+        return yield* runAddCommit({
+          branch: opts.branch,
+          mainBranch: opts.mainBranch,
+        });
+      case "rename-commit":
+        return yield* runRenameCommit(shared);
+      case "delete-commit":
+        return yield* runDeleteCommit(shared);
+    }
+  }).pipe(reportErrors);
+
+export const internal = CLICommand.make(
+  "internal",
+  {
+    branch: branchOption,
+    mainBranch: mainBranchOption,
+  },
+  runInternalPicker
+).pipe(
+  CLICommand.withSubcommands([
+    editCommit,
+    addCommit,
+    renameCommit,
+    deleteCommit,
+  ]),
+  CLICommand.withDescription("Internal commands for AI Hero")
 );

--- a/src/internal/rename-commit/command.ts
+++ b/src/internal/rename-commit/command.ts
@@ -1,0 +1,109 @@
+import { Command as CLICommand } from "@effect/cli";
+import type { Option } from "effect";
+import { Console, Effect } from "effect";
+import { runCeremony } from "../stack/ceremony.js";
+import {
+  branchOption,
+  commitOption,
+  mainBranchOption,
+  reportErrors,
+  requireInteractiveRepo,
+} from "../stack/options.js";
+import { loadCommits } from "../stack/session.js";
+import { promptForSubject } from "../stack/slug.js";
+import { labelOf, resolveTarget } from "../stack/target.js";
+import {
+  beginRenameSession,
+  renameSubject,
+} from "./session.js";
+
+export interface RenameCommitOptions {
+  commit: Option.Option<string>;
+  branch: string;
+  mainBranch: string;
+}
+
+/**
+ * Change a lesson's slug and title.
+ *
+ * Both prompts are prefilled with the current values, so Enter-Enter is a
+ * no-op and fixing only the title never forces you to retype the slug.
+ */
+export const runRenameCommit = (opts: RenameCommitOptions) =>
+  Effect.gen(function* () {
+    const liveBranch = opts.branch;
+
+    yield* requireInteractiveRepo("rename-commit");
+
+    const commits = yield* loadCommits({
+      branch: liveBranch,
+      mainBranch: opts.mainBranch,
+    });
+
+    const target = yield* resolveTarget({
+      commits,
+      commit: opts.commit,
+      promptMessage:
+        "Which lesson do you want to rename? (type to search)",
+    });
+
+    const label = labelOf(target);
+    yield* Console.log(`\nRenaming "${target.message}"`);
+
+    const { slug, subject } = yield* promptForSubject({
+      commits,
+      ...(target.lessonId === null
+        ? {}
+        : { initialSlug: target.lessonId }),
+      initialTitle: target.description,
+      // Keeping the commit's own slug is not a duplicate.
+      ...(target.lessonId === null
+        ? {}
+        : { allowExisting: target.lessonId }),
+    });
+
+    if (subject === target.message) {
+      yield* Console.log("Nothing changed.");
+      return;
+    }
+
+    const session = yield* beginRenameSession({
+      commits,
+      target,
+      liveBranch,
+    });
+
+    yield* runCeremony({
+      session,
+      label: slug,
+      verb: "renamed",
+      compose: Effect.gen(function* () {
+        yield* Console.log(
+          `\n${label} -> "${subject}" on ${session.tempBranch}`
+        );
+        yield* Console.log(
+          session.following === 0
+            ? `No commits follow ${label}.`
+            : `Will replay ${session.following} commit${
+                session.following === 1 ? "" : "s"
+              } after it.`
+        );
+
+        return yield* renameSubject({ session, subject });
+      }),
+    });
+  }).pipe(reportErrors);
+
+export const renameCommit = CLICommand.make(
+  "rename-commit",
+  {
+    commit: commitOption,
+    branch: branchOption,
+    mainBranch: mainBranchOption,
+  },
+  runRenameCommit
+).pipe(
+  CLICommand.withDescription(
+    "Change a lesson commit's slug and title"
+  )
+);

--- a/src/internal/rename-commit/session.ts
+++ b/src/internal/rename-commit/session.ts
@@ -1,0 +1,46 @@
+import { Effect } from "effect";
+import type { BranchCommit } from "../../branch-commits.js";
+import { GitService } from "../../git-service.js";
+import {
+  beginStackSession,
+  replayFollowing,
+  type StackSession,
+} from "../stack/session.js";
+
+/**
+ * Open a session with the temp branch parked *on* the target commit.
+ *
+ * Renaming amends in place rather than rebuilding from the parent, so the
+ * tree is untouched by construction — a rename can never alter a lesson's
+ * contents.
+ */
+export const beginRenameSession = (opts: {
+  commits: Array<BranchCommit>;
+  target: BranchCommit;
+  liveBranch: string;
+}) =>
+  beginStackSession({
+    liveBranch: opts.liveBranch,
+    base: opts.target.sha,
+    following: opts.commits.length - opts.target.sequence,
+    operation: "rename-commit",
+  });
+
+/**
+ * Re-author the target's subject, then replay the commits that followed it.
+ *
+ * Every downstream lesson gets a new SHA, which is free: students re-fetch,
+ * and nothing machine-readable pins a SHA or a slug. The cost of a reslug is
+ * human — recorded footage that names the old slug.
+ */
+export const renameSubject = (opts: {
+  session: StackSession;
+  subject: string;
+}) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    yield* git.amendCommitMessage(opts.subject);
+
+    return yield* replayFollowing(opts.session);
+  });

--- a/src/internal/stack/ceremony.ts
+++ b/src/internal/stack/ceremony.ts
@@ -1,0 +1,195 @@
+import { Console, Effect } from "effect";
+import { PromptService } from "../../prompt-service.js";
+import {
+  applyToLiveBranch,
+  conflictedFiles,
+  filesWithMarkers,
+  finish,
+  publish,
+  resumeCherryPick,
+  type StackSession,
+  unwind,
+} from "./session.js";
+
+/**
+ * The stage the session has reached, which decides how a cancellation unwinds.
+ *
+ *   editing  -> the operation's changes are in the working tree, uncommitted.
+ *   conflict -> a cherry-pick has stopped; resolved files are uncommitted.
+ *   composed -> everything is committed on the temp branch.
+ *   applied  -> the live branch has been moved onto the temp branch.
+ */
+export type Stage = "editing" | "conflict" | "composed" | "applied";
+
+/**
+ * Walk the cherry-pick conflict loop until it clears or the user aborts.
+ * Returns false when the user chose to abort the whole session.
+ *
+ * Written as a loop rather than a recursive effect so the error and
+ * requirement channels stay inferred.
+ */
+export const resolveConflicts = Effect.gen(function* () {
+  const prompts = yield* PromptService;
+
+  while (true) {
+    const files = yield* conflictedFiles;
+    yield* Console.log("\n⚠️  Cherry-pick conflict:");
+    for (const file of files) {
+      yield* Console.log(`   ${file}`);
+    }
+
+    const action =
+      yield* prompts.selectCherryPickConflictAction();
+
+    if (action === "abort") {
+      return false;
+    }
+
+    // Never take "continue" on trust — a committed `<<<<<<<` surfaces later as
+    // a broken exercise for students rather than immediately for the author.
+    const stillMarked = yield* filesWithMarkers;
+    if (stillMarked.length > 0) {
+      yield* Console.log(
+        "\nThese files still contain conflict markers:"
+      );
+      for (const file of stillMarked) {
+        yield* Console.log(`   ${file}`);
+      }
+      continue;
+    }
+
+    const result = yield* resumeCherryPick;
+    if (result.conflict) {
+      continue;
+    }
+
+    yield* Console.log("✓ Cherry-pick complete");
+    return true;
+  }
+});
+
+/**
+ * Run the shared tail every internal command ends in: resolve any replay
+ * conflict, confirm the save onto the live branch, confirm the force push,
+ * then return to the branch we started on.
+ *
+ * `compose` is the only part that differs between commands. It mutates the
+ * temp branch and reports whether the replay stopped on a conflict; everything
+ * either side of it — including how a cancellation unwinds — is identical, on
+ * purpose. Four copies of `unwind` is how orphaned branches come back.
+ */
+export const runCeremony = <E, R>(opts: {
+  session: StackSession;
+  /** Human name for the lesson being operated on, for progress output. */
+  label: string;
+  /** Past-tense summary line, e.g. "added" or "deleted". */
+  verb: string;
+  compose: Effect.Effect<{ conflict: boolean }, E, R>;
+}) =>
+  Effect.gen(function* () {
+    const prompts = yield* PromptService;
+    const { label, session } = opts;
+
+    let stage: Stage = "editing";
+
+    const body = Effect.gen(function* () {
+      const result = yield* opts.compose;
+
+      if (result.conflict) {
+        stage = "conflict";
+        const resolved = yield* resolveConflicts;
+        if (!resolved) {
+          yield* Console.log("Aborting session…");
+          const { discardedFiles } = yield* unwind(session, {
+            midCherryPick: true,
+            liveBranchMoved: false,
+            keepTempBranch: false,
+          });
+          yield* Console.log(
+            `✓ Restored ${session.originalBranch}; discarded ${discardedFiles.length} path(s)`
+          );
+          return;
+        }
+      }
+
+      stage = "composed";
+      yield* Console.log(`\n✓ ${label} ${opts.verb}`);
+
+      yield* prompts.confirmSaveToTargetBranch(
+        session.liveBranch
+      );
+      yield* applyToLiveBranch(session);
+      stage = "applied";
+      yield* Console.log(
+        `✓ ${session.liveBranch} updated with your changes`
+      );
+
+      yield* prompts.confirmForcePush(session.liveBranch);
+      yield* publish(session);
+      yield* Console.log(
+        `✓ Pushed ${session.liveBranch} to origin`
+      );
+
+      yield* finish(session);
+      yield* Console.log(
+        `✓ Switched back to ${session.originalBranch}`
+      );
+
+      if (session.backupBranch) {
+        yield* Console.log(
+          `  Backup of the previous history: ${session.backupBranch}`
+        );
+      }
+    });
+
+    /**
+     * Cancelling a prompt unwinds in-process. Before the changes are committed
+     * we ask first, because the unwind throws away hand-written work (conflict
+     * resolutions included); once they're committed we unwind silently but
+     * keep the temp branch, so backing out of a push never costs you the work.
+     */
+    const onCancel = Effect.gen(function* () {
+      if (stage === "editing" || stage === "conflict") {
+        const discard = yield* prompts.confirmDiscardChanges(
+          session.tempBranch
+        );
+
+        if (!discard) {
+          yield* Console.log(
+            `Cancelled. Your changes are on ${session.tempBranch}.`
+          );
+          return;
+        }
+
+        const { discardedFiles } = yield* unwind(session, {
+          midCherryPick: stage === "conflict",
+          liveBranchMoved: false,
+          keepTempBranch: false,
+        });
+        yield* Console.log(
+          `✓ Restored ${session.originalBranch}; discarded ${discardedFiles.length} path(s)`
+        );
+        return;
+      }
+
+      yield* unwind(session, {
+        midCherryPick: false,
+        liveBranchMoved: stage === "applied",
+        keepTempBranch: true,
+      });
+      yield* Console.log(
+        `Cancelled. Your recomposed branch is ${session.tempBranch}.`
+      );
+    });
+
+    yield* body.pipe(
+      Effect.catchTag("PromptCancelledError", () => onCancel),
+      // A hard interrupt can't prompt, so leave everything alone and print
+      // the breadcrumb needed to find the work again.
+      Effect.onInterrupt(() =>
+        Console.log(
+          `\nInterrupted. Your session is on ${session.tempBranch}.`
+        )
+      )
+    );
+  });

--- a/src/internal/stack/options.ts
+++ b/src/internal/stack/options.ts
@@ -1,0 +1,106 @@
+import { Options } from "@effect/cli";
+import { Console, Data, Effect } from "effect";
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+import { DEFAULT_PROJECT_TARGET_BRANCH } from "../../constants.js";
+import { NotAGitRepoError } from "./session.js";
+
+export class NotATtyError extends Data.TaggedError(
+  "NotATtyError"
+)<{
+  command: string;
+}> {}
+
+export const commitOption = Options.text("commit").pipe(
+  Options.withAlias("c"),
+  Options.withDescription(
+    "Lesson to act on: a lesson id (slug or numeric) or a SHA prefix. Omit to pick from a list."
+  ),
+  Options.optional
+);
+
+export const branchOption = Options.text("branch").pipe(
+  Options.withDescription("The live branch holding the commits"),
+  Options.withDefault(DEFAULT_PROJECT_TARGET_BRANCH)
+);
+
+export const mainBranchOption = Options.text("main-branch").pipe(
+  Options.withDescription("The base branch of the project"),
+  Options.withDefault("main")
+);
+
+/**
+ * The preconditions every internal command shares: a git repo, and a TTY.
+ *
+ * These commands are interactive by design. Rather than silently degrading
+ * into a non-interactive mode, they refuse — a caller without a TTY is
+ * reaching for something they no longer offer.
+ */
+export const requireInteractiveRepo = (command: string) =>
+  Effect.gen(function* () {
+    const cwd = process.cwd();
+
+    if (!existsSync(path.join(cwd, ".git"))) {
+      return yield* new NotAGitRepoError({ path: cwd });
+    }
+
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      return yield* new NotATtyError({ command });
+    }
+  });
+
+/**
+ * The error reporting every internal command shares. Kept in one place so a
+ * new command can't quietly forget to handle a failure the others report.
+ */
+export const reportErrors = <A, E, R>(
+  effect: Effect.Effect<A, E, R>
+) =>
+  effect.pipe(
+    Effect.catchAll((error) =>
+      Effect.gen(function* () {
+        // Matched on `_tag` rather than via `catchTags` so this stays one
+        // copy: each command's error channel is a slightly different union,
+        // and a typed combinator would have to be re-specialised per command.
+        const tagged = error as {
+          _tag?: string;
+          path?: string;
+          command?: string;
+          liveBranch?: string;
+          mainBranch?: string;
+          commit?: string;
+        };
+
+        switch (tagged._tag) {
+          case "NotAGitRepoError":
+            yield* Console.error(
+              `Error: not a git repository: ${tagged.path}`
+            );
+            break;
+          case "NotATtyError":
+            yield* Console.error(
+              `Error: \`${tagged.command}\` is interactive and needs a TTY.`
+            );
+            break;
+          case "NoCommitsFoundError":
+            yield* Console.error(
+              `Error: No commits found on ${tagged.liveBranch} beyond ${tagged.mainBranch}`
+            );
+            break;
+          case "CommitNotFoundError":
+            yield* Console.error(
+              `Error: No lesson matching "${tagged.commit}"`
+            );
+            break;
+          case "PromptCancelledError":
+            yield* Console.log("Cancelled.");
+            // A cancellation is a normal exit, not a failure.
+            return;
+          default:
+            yield* Console.error(`Unexpected error: ${error}`);
+        }
+
+        process.exitCode = 1;
+      })
+    )
+  );

--- a/src/internal/stack/session.ts
+++ b/src/internal/stack/session.ts
@@ -1,0 +1,296 @@
+import { FileSystem } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import { Data, Effect } from "effect";
+import * as path from "node:path";
+import { getCommitsBetweenBranches } from "../../branch-commits.js";
+import type { CherryPickConflictError } from "../../git-service/errors.js";
+import { GitService, GitServiceConfig } from "../../git-service.js";
+
+export class NotAGitRepoError extends Data.TaggedError(
+  "NotAGitRepoError"
+)<{
+  path: string;
+}> {}
+
+/**
+ * A live rewrite of the lesson stack, held in one process and deliberately
+ * **not** persisted — a session that outlives its process is not resumable.
+ *
+ * Every internal command is the same spine with a different middle: park a
+ * temp branch at some base, do the thing, replay everything that followed,
+ * then apply / publish / finish — or `unwind` back to how we found it.
+ */
+export interface StackSession {
+  tempBranch: string;
+  originalBranch: string;
+  liveBranch: string;
+  /** Live branch tip before the session began — what we replay up to. */
+  targetBranchHead: string;
+  /**
+   * Replay commits *after* this sha. Distinct from the temp branch's base:
+   * `delete` bases at the target's parent but still replays from the target,
+   * which is precisely what drops it.
+   */
+  replayFrom: string;
+  /** Number of commits that will be replayed. For display only. */
+  following: number;
+  /** Backup branch taken before a destructive rewrite, if any. */
+  backupBranch: string | null;
+}
+
+/** Fetch origin and read the lesson stack, oldest first. */
+export const loadCommits = (opts: {
+  branch: string;
+  mainBranch: string;
+}) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    yield* git.fetchOrigin();
+
+    return yield* getCommitsBetweenBranches({
+      mainBranch: opts.mainBranch,
+      liveBranch: opts.branch,
+    });
+  });
+
+/**
+ * Read the lesson stack, tolerating an empty one.
+ *
+ * Only `add-commit` uses this: "there are no lessons yet" is a perfectly good
+ * state to be adding the first lesson from, whereas edit/rename/delete have
+ * nothing to act on and should keep failing loudly.
+ */
+export const loadCommitsAllowingEmpty = (opts: {
+  branch: string;
+  mainBranch: string;
+}) =>
+  loadCommits(opts).pipe(
+    Effect.catchTag("NoCommitsFoundError", () => Effect.succeed([]))
+  );
+
+/**
+ * Open a session on a fresh temp branch based at `base`.
+ *
+ * The caller resolves everything it needs *before* calling this, so a bad
+ * reference can never strand a temp branch.
+ */
+export const beginStackSession = (opts: {
+  liveBranch: string;
+  /** Where the temp branch starts. */
+  base: string;
+  /** Replay commits after this sha (defaults to `base`). */
+  replayFrom?: string;
+  following: number;
+  /** Name prefix for the temp branch, e.g. "edit-commit". */
+  operation: string;
+  /** Snapshot the live branch under `backup/` before rewriting. */
+  backup?: boolean;
+}) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    const targetBranchHead = yield* git.revParse(opts.liveBranch);
+    const originalBranch = yield* git.getCurrentBranch();
+
+    // The backup is taken before anything moves, so it always names the
+    // pre-rewrite tip even if the session later unwinds badly.
+    let backupBranch: string | null = null;
+    if (opts.backup) {
+      backupBranch = `backup/${opts.liveBranch}-pre-${
+        opts.operation
+      }-${Date.now()}`;
+      yield* git.createBranchAt(backupBranch, targetBranchHead);
+    }
+
+    const tempBranch = `matt/${opts.operation}-${Date.now()}`;
+    yield* git.checkoutNewBranchAt(tempBranch, opts.base);
+
+    return {
+      tempBranch,
+      originalBranch,
+      liveBranch: opts.liveBranch,
+      targetBranchHead,
+      replayFrom: opts.replayFrom ?? opts.base,
+      following: opts.following,
+      backupBranch,
+    } satisfies StackSession;
+  });
+
+/** All changed paths parsed from `git status --short`. */
+const parseStatusPaths = (status: string) =>
+  status
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => ({
+      xy: line.slice(0, 2),
+      path: line.slice(3).trim(),
+    }));
+
+/** Files with unmerged paths, parsed from `git status --short`. */
+export const conflictedFiles = Effect.gen(function* () {
+  const git = yield* GitService;
+  const status = yield* git.getStatusShort();
+  return parseStatusPaths(status)
+    .filter(
+      ({ xy }) => xy.includes("U") || xy === "AA" || xy === "DD"
+    )
+    .map((entry) => entry.path);
+});
+
+/**
+ * Of the currently-unmerged files, those that still contain conflict markers.
+ *
+ * The point of actually reading the files: "continue" must not take the user's
+ * word for it and commit `<<<<<<<` into a lesson, where it surfaces later as a
+ * broken exercise for students rather than immediately for the author.
+ */
+export const filesWithMarkers = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const { cwd } = yield* GitServiceConfig;
+  const unmerged = yield* conflictedFiles;
+
+  const remaining: Array<string> = [];
+  for (const file of unmerged) {
+    const content = yield* fs.readFileString(
+      path.join(cwd, file)
+    );
+    if (
+      content.includes("<<<<<<<") ||
+      content.includes(">>>>>>>")
+    ) {
+      remaining.push(file);
+    }
+  }
+  return remaining;
+});
+
+/**
+ * Run a cherry-pick effect and report whether it stopped on a conflict,
+ * folding the typed conflict error into a plain boolean result.
+ */
+export const detectConflict = <A, R>(
+  effect: Effect.Effect<
+    A,
+    CherryPickConflictError | PlatformError,
+    R
+  >
+) =>
+  effect.pipe(
+    Effect.map(() => ({ conflict: false as const })),
+    Effect.catchTag("CherryPickConflictError", () =>
+      Effect.succeed({ conflict: true as const })
+    )
+  );
+
+/**
+ * Replay the commits that followed onto the temp branch. Reports whether the
+ * replay stopped on a conflict.
+ */
+export const replayFollowing = (session: StackSession) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    if (session.following === 0) {
+      return { conflict: false as const };
+    }
+
+    return yield* detectConflict(
+      git.cherryPick(
+        `${session.replayFrom}..${session.targetBranchHead}`
+      )
+    );
+  });
+
+/** Resume a conflicted cherry-pick from the resolved working tree. */
+export const resumeCherryPick = Effect.gen(function* () {
+  const git = yield* GitService;
+  yield* git.stageAll();
+  return yield* detectConflict(git.cherryPickContinue());
+});
+
+/** Move the live branch onto the recomposed temp branch. */
+export const applyToLiveBranch = (session: StackSession) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+    yield* git.checkout(session.liveBranch);
+    yield* git.resetHard(session.tempBranch);
+  });
+
+/** Force-push the recomposed live branch to origin. */
+export const publish = (session: StackSession) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+    yield* git.pushForceWithLease("origin", session.liveBranch);
+  });
+
+/** Return to the branch we started on and drop the temp branch. */
+export const finish = (session: StackSession) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+    yield* git.checkout(session.originalBranch);
+    yield* git.deleteBranch(session.tempBranch);
+  });
+
+export interface UnwindOptions {
+  /** A cherry-pick is mid-flight and must be aborted first. */
+  midCherryPick: boolean;
+  /** The live branch has already been moved onto the temp branch. */
+  liveBranchMoved: boolean;
+  /**
+   * Leave the temp branch in place rather than deleting it. Used once the
+   * user's edits are committed: backing out of publishing shouldn't throw the
+   * edits away, so we restore every *other* branch and hand back the name.
+   */
+  keepTempBranch: boolean;
+}
+
+/**
+ * Tear the session down and restore the repository to how we found it.
+ *
+ * This is the fix for the old command's worst behaviour: cancelling a prompt
+ * printed "Branch left as-is" and abandoned a `matt/edit-commit-*` branch that
+ * nothing could later find. Returns the working-tree paths it discarded.
+ *
+ * Deliberately shared by all four commands rather than copied: divergent
+ * unwind logic is exactly how orphaned branches come back.
+ */
+export const unwind = (
+  session: StackSession,
+  opts: UnwindOptions
+) =>
+  Effect.gen(function* () {
+    const git = yield* GitService;
+
+    const discardedFiles = opts.keepTempBranch
+      ? []
+      : parseStatusPaths(yield* git.getStatusShort()).map(
+          (entry) => entry.path
+        );
+
+    if (opts.midCherryPick) {
+      yield* git.cherryPickAbort();
+    }
+
+    if (!opts.keepTempBranch && !opts.liveBranchMoved) {
+      // Still parked on the temp branch with a dirty tree — clear it so the
+      // checkout below can't be blocked by uncommitted changes.
+      yield* git.resetHard(session.tempBranch);
+      yield* git.clean();
+    }
+
+    if (opts.liveBranchMoved) {
+      // The live branch was already reset onto the temp branch; put it back
+      // where it was before the session started.
+      yield* git.checkout(session.liveBranch);
+      yield* git.resetHard(session.targetBranchHead);
+    }
+
+    yield* git.checkout(session.originalBranch);
+
+    if (!opts.keepTempBranch) {
+      yield* git.deleteBranch(session.tempBranch);
+    }
+
+    return { discardedFiles };
+  });

--- a/src/internal/stack/slug.ts
+++ b/src/internal/stack/slug.ts
@@ -1,0 +1,114 @@
+import { Console, Effect } from "effect";
+import type { BranchCommit } from "../../branch-commits.js";
+import { PromptService } from "../../prompt-service.js";
+
+/** The parse boundary a slug must never contain. */
+const LESSON_ID_BOUNDARY = ": ";
+
+const KEBAB_CASE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export type SlugRejection = { ok: false; reason: string };
+export type SlugCheck = { ok: true } | SlugRejection;
+
+/**
+ * Whether `slug` may be used as a lesson id.
+ *
+ * This is the first place in the CLI where the slug convention is enforced in
+ * code rather than in prose — every other command reuses a message that
+ * already exists, so nothing has ever had to validate one. The rules come from
+ * the maintainer's contract: kebab-case, no `": "` (it *is* the parse
+ * boundary), and unique within the stack, because `reset` silently picks the
+ * latest of a duplicate pair.
+ */
+export const checkSlug = (opts: {
+  slug: string;
+  commits: Array<BranchCommit>;
+  /** A slug already owned by the commit being renamed, which may be kept. */
+  allowExisting?: string | undefined;
+}): SlugCheck => {
+  const slug = opts.slug.trim();
+
+  if (slug === "") {
+    return { ok: false, reason: "A slug is required." };
+  }
+
+  if (slug.includes(LESSON_ID_BOUNDARY)) {
+    return {
+      ok: false,
+      reason: `A slug cannot contain "${LESSON_ID_BOUNDARY}" — that is the parse boundary.`,
+    };
+  }
+
+  if (!KEBAB_CASE.test(slug)) {
+    return {
+      ok: false,
+      reason:
+        "A slug must be lowercase kebab-case (e.g. add-settings-json).",
+    };
+  }
+
+  const isDuplicate = opts.commits.some(
+    (commit) =>
+      commit.lessonId === slug && slug !== opts.allowExisting
+  );
+
+  if (isDuplicate) {
+    return {
+      ok: false,
+      reason: `"${slug}" is already used by another lesson. Slugs must be unique — a duplicate is a silent trap for \`reset\`.`,
+    };
+  }
+
+  return { ok: true };
+};
+
+/** Compose a lesson commit subject from its two halves. */
+export const composeSubject = (opts: {
+  slug: string;
+  title: string;
+}) => `${opts.slug.trim()}${LESSON_ID_BOUNDARY}${opts.title.trim()}`;
+
+/**
+ * Prompt for a slug and then a title, re-prompting until the slug is valid.
+ *
+ * Both prompts take an initial value, so `rename-commit` can prefill the
+ * current values and Enter-Enter is a no-op.
+ */
+export const promptForSubject = (opts: {
+  commits: Array<BranchCommit>;
+  initialSlug?: string | undefined;
+  initialTitle?: string | undefined;
+  allowExisting?: string | undefined;
+}) =>
+  Effect.gen(function* () {
+    const prompts = yield* PromptService;
+
+    let slug: string;
+    while (true) {
+      const entered = yield* prompts.inputSlug(opts.initialSlug);
+      const check = checkSlug({
+        slug: entered,
+        commits: opts.commits,
+        allowExisting: opts.allowExisting,
+      });
+
+      if (check.ok) {
+        slug = entered.trim();
+        break;
+      }
+
+      yield* Console.log(`\n✗ ${check.reason}\n`);
+    }
+
+    let title: string;
+    while (true) {
+      const entered = yield* prompts.inputTitle(opts.initialTitle);
+      if (entered.trim() !== "") {
+        title = entered.trim();
+        break;
+      }
+      yield* Console.log("\n✗ A title is required.\n");
+    }
+
+    return { slug, title, subject: composeSubject({ slug, title }) };
+  });

--- a/src/internal/stack/target.ts
+++ b/src/internal/stack/target.ts
@@ -1,0 +1,39 @@
+import { Effect, Option } from "effect";
+import {
+  type BranchCommit,
+  CommitNotFoundError,
+  resolveCommitRef,
+  selectCommit,
+} from "../../branch-commits.js";
+
+/**
+ * Resolve the lesson a command should act on — from `--commit` when given,
+ * otherwise by asking.
+ *
+ * Always called *before* a session opens, so a bad reference can't strand a
+ * temp branch.
+ */
+export const resolveTarget = (opts: {
+  commits: Array<BranchCommit>;
+  commit: Option.Option<string>;
+  promptMessage: string;
+}) =>
+  Effect.gen(function* () {
+    if (Option.isSome(opts.commit)) {
+      return (
+        resolveCommitRef(opts.commits, opts.commit.value) ??
+        (yield* new CommitNotFoundError({
+          commit: opts.commit.value,
+        }))
+      );
+    }
+
+    return yield* selectCommit({
+      commits: opts.commits,
+      promptMessage: opts.promptMessage,
+    });
+  });
+
+/** How a lesson is named in progress output. */
+export const labelOf = (commit: BranchCommit) =>
+  commit.lessonId ?? commit.sha;

--- a/src/prompt-service.ts
+++ b/src/prompt-service.ts
@@ -762,6 +762,224 @@ export class PromptService extends Effect.Service<PromptService>()(
         }
       );
 
+      /**
+       * Prompts for a lesson slug — the durable id, named for the change.
+       *
+       * @param initial - Prefilled value, for renaming an existing lesson
+       * @returns The entered slug (unvalidated; see `checkSlug`)
+       * @throws PromptCancelledError if user presses Ctrl+C
+       */
+      const inputSlug = Effect.fn("inputSlug")(function* (
+        initial?: string | undefined
+      ) {
+        const { slug } = yield* runPrompt<{ slug: string }>(() =>
+          prompt([
+            {
+              type: "text",
+              name: "slug",
+              message:
+                "Slug (the durable id, named for the change — e.g. add-settings-json):",
+              ...(initial === undefined ? {} : { initial }),
+            },
+          ])
+        );
+
+        return slug ?? "";
+      });
+
+      /**
+       * Prompts for a lesson title — the human half of the subject, free to
+       * change later.
+       *
+       * @param initial - Prefilled value, for renaming an existing lesson
+       * @returns The entered title
+       * @throws PromptCancelledError if user presses Ctrl+C
+       */
+      const inputTitle = Effect.fn("inputTitle")(function* (
+        initial?: string | undefined
+      ) {
+        const { title } = yield* runPrompt<{ title: string }>(
+          () =>
+            prompt([
+              {
+                type: "text",
+                name: "title",
+                message: "Title:",
+                ...(initial === undefined ? {} : { initial }),
+              },
+            ])
+        );
+
+        return title ?? "";
+      });
+
+      /**
+       * Prompts for where a new lesson should be inserted.
+       *
+       * The two boundary choices are pinned: "at the start" first, "at the
+       * end" last, with the existing lessons in teaching order between them.
+       *
+       * @param lessons - Existing lessons, in teaching order
+       * @returns "start", "end", or the lesson id to insert after
+       * @throws PromptCancelledError if user presses Ctrl+C
+       */
+      const selectInsertPosition = Effect.fn(
+        "selectInsertPosition"
+      )(function* (
+        lessons: Array<{ lessonId: string; message: string }>
+      ) {
+        const START = " start";
+        const END = " end";
+
+        const choices = [
+          {
+            title: "── at the start ──",
+            value: START,
+            description: "Before the first lesson",
+          },
+          ...lessons.map((lesson) => ({
+            title: `after ${lesson.lessonId}`,
+            value: lesson.lessonId,
+            description: lesson.message,
+          })),
+          {
+            title: "── at the end ──",
+            value: END,
+            description: "After the last lesson",
+          },
+        ];
+
+        const { position } = yield* runPrompt<{
+          position: string;
+        }>(() =>
+          prompt([
+            {
+              type: "autocomplete",
+              name: "position",
+              message: "Where should the new lesson go?",
+              choices,
+              suggest: async (
+                input: string,
+                options: Array<{
+                  title: string;
+                  value: string;
+                  description: string;
+                }>
+              ) => {
+                const lowerInput = input.toLowerCase().trim();
+                if (lowerInput === "") {
+                  return options;
+                }
+                return options.filter((choice) =>
+                  `${choice.title} ${choice.description}`
+                    .toLowerCase()
+                    .includes(lowerInput)
+                );
+              },
+            },
+          ])
+        );
+
+        if (position === START) {
+          return { _tag: "start" as const };
+        }
+        if (position === END) {
+          return { _tag: "end" as const };
+        }
+        return { _tag: "after" as const, lessonId: position };
+      });
+
+      /**
+       * Confirms a lesson deletion, having shown what it destroys.
+       * Default is false (no) — this is the only op that discards authored
+       * work rather than moving it.
+       *
+       * @throws PromptCancelledError if user declines or cancels
+       */
+      const confirmDeleteLesson = Effect.fn(
+        "confirmDeleteLesson"
+      )(function* (opts: { label: string; following: number }) {
+        const replay =
+          opts.following === 0
+            ? "Nothing follows it."
+            : `This will replay ${opts.following} commit${
+                opts.following === 1 ? "" : "s"
+              } after it.`;
+
+        const { confirm } = yield* runPrompt<{
+          confirm: boolean;
+        }>(() =>
+          prompt([
+            {
+              type: "confirm",
+              name: "confirm",
+              message: `Delete ${opts.label}? ${replay}`,
+              initial: false,
+            },
+          ])
+        );
+
+        if (!confirm) {
+          return yield* new PromptCancelledError();
+        }
+      });
+
+      /**
+       * The menu shown by a bare `internal` invocation.
+       *
+       * Edit first — it's the one used daily. Delete last, so a stray Enter
+       * can't reach the destructive one.
+       *
+       * @returns The selected command name
+       * @throws PromptCancelledError if user presses Ctrl+C
+       */
+      const selectInternalCommand = Effect.fn(
+        "selectInternalCommand"
+      )(function* () {
+        const { command } = yield* runPrompt<{
+          command:
+            | "edit-commit"
+            | "add-commit"
+            | "rename-commit"
+            | "delete-commit";
+        }>(() =>
+          prompt([
+            {
+              type: "select",
+              name: "command",
+              message: "What would you like to do?",
+              choices: [
+                {
+                  title: "edit-commit",
+                  value: "edit-commit",
+                  description:
+                    "Edit a lesson's contents and replay the commits after it",
+                },
+                {
+                  title: "add-commit",
+                  value: "add-commit",
+                  description:
+                    "Add an empty stub lesson to fill in later",
+                },
+                {
+                  title: "rename-commit",
+                  value: "rename-commit",
+                  description: "Change a lesson's slug and title",
+                },
+                {
+                  title: "delete-commit",
+                  value: "delete-commit",
+                  description:
+                    "Remove a lesson from the history entirely",
+                },
+              ],
+            },
+          ])
+        );
+
+        return command;
+      });
+
       return {
         confirmReadyToCommit,
         confirmSaveToTargetBranch,
@@ -781,6 +999,11 @@ export class PromptService extends Effect.Service<PromptService>()(
         selectSubdirectory,
         inputText,
         inputRepoName,
+        inputSlug,
+        inputTitle,
+        selectInsertPosition,
+        confirmDeleteLesson,
+        selectInternalCommand,
       };
     }),
     dependencies: [],

--- a/test/add-commit.test.ts
+++ b/test/add-commit.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { resolveCommitRef } from "../src/branch-commits.js";
+import {
+  beginAddSession,
+  composeStub,
+  type InsertPosition,
+} from "../src/internal/add-commit/session.js";
+import {
+  applyToLiveBranch,
+  finish,
+  loadCommits,
+  loadCommitsAllowingEmpty,
+  publish,
+} from "../src/internal/stack/session.js";
+import { composeSubject } from "../src/internal/stack/slug.js";
+import {
+  commit,
+  createTestRepo,
+} from "./helpers/create-test-repo.js";
+import { git, makeLayer, stackOf } from "./helpers/make-layer.js";
+
+/**
+ * Integration tests for add-commit's git layer, against a real repo + bare
+ * remote. The slug/title prompts sit above these functions.
+ */
+describe("add-commit session", () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  const makeRepo = () => {
+    const repo = createTestRepo()
+      .withRemote("origin")
+      .withBranch("main", [
+        commit("base", { "base.txt": "base" }),
+      ])
+      .withBranch("live-run-through", [
+        commit("add-first: First", { "a.txt": "first" }),
+        commit("add-second: Second", { "b.txt": "second" }),
+        commit("add-third: Third", { "c.txt": "third" }),
+      ])
+      .build();
+    cleanup = repo.cleanup;
+    return repo;
+  };
+
+  /** A repo whose live branch carries no lessons at all. */
+  const makeEmptyStackRepo = () => {
+    const repo = createTestRepo()
+      .withRemote("origin")
+      .withBranch("main", [
+        commit("base", { "base.txt": "base" }),
+      ])
+      .withBranch("live-run-through", [])
+      .build();
+    cleanup = repo.cleanup;
+    return repo;
+  };
+
+  const subject = composeSubject({
+    slug: "add-stub",
+    title: "A stub",
+  });
+
+  /** Run a full add through to the live branch. */
+  const addAt = (position: (commits: never) => InsertPosition) =>
+    Effect.gen(function* () {
+      const commits = yield* loadCommits({
+        branch: "live-run-through",
+        mainBranch: "main",
+      });
+
+      const session = yield* beginAddSession({
+        commits,
+        position: position(commits as never),
+        liveBranch: "live-run-through",
+      });
+
+      const result = yield* composeStub({ session, subject });
+      expect(result.conflict).toBe(false);
+
+      yield* applyToLiveBranch(session);
+      yield* finish(session);
+      return session;
+    });
+
+  it.effect("adds a stub at the end of the stack", () => {
+    const { workingDir } = makeRepo();
+
+    return addAt(() => ({ _tag: "end" })).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(stackOf(workingDir)).toEqual([
+            "add-first: First",
+            "add-second: Second",
+            "add-third: Third",
+            subject,
+          ]);
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("adds a stub at the start of the stack", () => {
+    const { workingDir } = makeRepo();
+
+    return addAt(() => ({ _tag: "start" })).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(stackOf(workingDir)).toEqual([
+            subject,
+            "add-first: First",
+            "add-second: Second",
+            "add-third: Third",
+          ]);
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("adds a stub after a chosen lesson", () => {
+    const { workingDir } = makeRepo();
+
+    return addAt((commits) => ({
+      _tag: "after",
+      commit: resolveCommitRef(commits, "add-first")!,
+    })).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(stackOf(workingDir)).toEqual([
+            "add-first: First",
+            subject,
+            "add-second: Second",
+            "add-third: Third",
+          ]);
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("the stub it adds is empty", () => {
+    const { workingDir } = makeRepo();
+
+    return addAt(() => ({ _tag: "end" })).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          // No paths in the diff against its parent.
+          const changed = git(
+            workingDir,
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            "live-run-through"
+          );
+          expect(changed).toBe("");
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("preserves the contents of replayed lessons", () => {
+    const { workingDir } = makeRepo();
+
+    return addAt(() => ({ _tag: "start" })).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(
+            git(workingDir, "show", "live-run-through:c.txt")
+          ).toBe("third");
+          expect(
+            git(workingDir, "show", "live-run-through:a.txt")
+          ).toBe("first");
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("adds the first lesson to an empty stack", () => {
+    const { workingDir } = makeEmptyStackRepo();
+
+    return Effect.gen(function* () {
+      const commits = yield* loadCommitsAllowingEmpty({
+        branch: "live-run-through",
+        mainBranch: "main",
+      });
+      expect(commits).toEqual([]);
+
+      const session = yield* beginAddSession({
+        commits,
+        position: { _tag: "end" },
+        liveBranch: "live-run-through",
+      });
+
+      const result = yield* composeStub({ session, subject });
+      expect(result.conflict).toBe(false);
+      expect(session.following).toBe(0);
+
+      yield* applyToLiveBranch(session);
+      yield* finish(session);
+
+      expect(stackOf(workingDir)).toEqual([subject]);
+    }).pipe(Effect.provide(makeLayer(workingDir)));
+  });
+
+  it.effect("publishes the new stack to origin", () => {
+    const { workingDir } = makeRepo();
+
+    return Effect.gen(function* () {
+      const commits = yield* loadCommits({
+        branch: "live-run-through",
+        mainBranch: "main",
+      });
+
+      const session = yield* beginAddSession({
+        commits,
+        position: { _tag: "end" },
+        liveBranch: "live-run-through",
+      });
+
+      yield* composeStub({ session, subject });
+      yield* applyToLiveBranch(session);
+      yield* publish(session);
+      yield* finish(session);
+
+      const remote = git(
+        workingDir,
+        "log",
+        "--format=%s",
+        "-1",
+        "origin/live-run-through"
+      );
+      expect(remote).toBe(subject);
+    }).pipe(Effect.provide(makeLayer(workingDir)));
+  });
+});

--- a/test/delete-commit.test.ts
+++ b/test/delete-commit.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { resolveCommitRef } from "../src/branch-commits.js";
+import {
+  beginDeleteSession,
+  replayWithoutTarget,
+} from "../src/internal/delete-commit/session.js";
+import {
+  applyToLiveBranch,
+  conflictedFiles,
+  finish,
+  loadCommits,
+  unwind,
+} from "../src/internal/stack/session.js";
+import {
+  commit,
+  createTestRepo,
+} from "./helpers/create-test-repo.js";
+import { git, makeLayer, stackOf } from "./helpers/make-layer.js";
+
+describe("delete-commit session", () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  const makeRepo = () => {
+    const repo = createTestRepo()
+      .withRemote("origin")
+      .withBranch("main", [
+        commit("base", { "base.txt": "base" }),
+      ])
+      .withBranch("live-run-through", [
+        commit("add-first: First", { "a.txt": "first" }),
+        commit("add-second: Second", { "b.txt": "second" }),
+        commit("add-third: Third", { "c.txt": "third" }),
+      ])
+      .build();
+    cleanup = repo.cleanup;
+    return repo;
+  };
+
+  /** A stack where each lesson edits the same file, so a delete conflicts. */
+  const makeConflictingRepo = () => {
+    const repo = createTestRepo()
+      .withRemote("origin")
+      .withBranch("main", [
+        commit("base", { "base.txt": "base" }),
+      ])
+      .withBranch("live-run-through", [
+        commit("add-first: First", { "shared.txt": "v1\n" }),
+        commit("add-second: Second", { "shared.txt": "v2\n" }),
+        commit("add-third: Third", { "shared.txt": "v3\n" }),
+      ])
+      .build();
+    cleanup = repo.cleanup;
+    return repo;
+  };
+
+  const deleteLesson = (ref: string) =>
+    Effect.gen(function* () {
+      const commits = yield* loadCommits({
+        branch: "live-run-through",
+        mainBranch: "main",
+      });
+      const target = resolveCommitRef(commits, ref)!;
+
+      const session = yield* beginDeleteSession({
+        commits,
+        target,
+        liveBranch: "live-run-through",
+      });
+
+      const result = yield* replayWithoutTarget(session);
+      return { session, result };
+    });
+
+  it.effect("drops a mid-stack lesson and replays the rest", () => {
+    const { workingDir } = makeRepo();
+
+    return Effect.gen(function* () {
+      const { result, session } = yield* deleteLesson(
+        "add-second"
+      );
+      expect(result.conflict).toBe(false);
+
+      yield* applyToLiveBranch(session);
+      yield* finish(session);
+
+      expect(stackOf(workingDir)).toEqual([
+        "add-first: First",
+        "add-third: Third",
+      ]);
+      // The deleted lesson's file is gone; the survivor's remains.
+      expect(
+        git(workingDir, "show", "live-run-through:c.txt")
+      ).toBe("third");
+      expect(() =>
+        git(workingDir, "show", "live-run-through:b.txt")
+      ).toThrow();
+    }).pipe(Effect.provide(makeLayer(workingDir)));
+  });
+
+  it.effect("drops the tip, replaying nothing", () => {
+    const { workingDir } = makeRepo();
+
+    return Effect.gen(function* () {
+      const { result, session } = yield* deleteLesson("add-third");
+      expect(session.following).toBe(0);
+      expect(result.conflict).toBe(false);
+
+      yield* applyToLiveBranch(session);
+      yield* finish(session);
+
+      expect(stackOf(workingDir)).toEqual([
+        "add-first: First",
+        "add-second: Second",
+      ]);
+    }).pipe(Effect.provide(makeLayer(workingDir)));
+  });
+
+  it.effect("drops the first lesson, replaying all the rest", () => {
+    const { workingDir } = makeRepo();
+
+    return Effect.gen(function* () {
+      const { result, session } = yield* deleteLesson("add-first");
+      expect(session.following).toBe(2);
+      expect(result.conflict).toBe(false);
+
+      yield* applyToLiveBranch(session);
+      yield* finish(session);
+
+      expect(stackOf(workingDir)).toEqual([
+        "add-second: Second",
+        "add-third: Third",
+      ]);
+    }).pipe(Effect.provide(makeLayer(workingDir)));
+  });
+
+  it.effect("takes a backup branch before rewriting", () => {
+    const { workingDir } = makeRepo();
+
+    return Effect.gen(function* () {
+      const before = git(
+        workingDir,
+        "rev-parse",
+        "live-run-through"
+      );
+
+      const { session } = yield* deleteLesson("add-second");
+      expect(session.backupBranch).toMatch(
+        /^backup\/live-run-through-pre-delete-commit-\d+$/
+      );
+
+      yield* applyToLiveBranch(session);
+      yield* finish(session);
+
+      // The backup still names the pre-delete tip.
+      expect(
+        git(workingDir, "rev-parse", session.backupBranch!)
+      ).toBe(before);
+      expect(stackOf(workingDir, session.backupBranch!)).toEqual([
+        "add-first: First",
+        "add-second: Second",
+        "add-third: Third",
+      ]);
+    }).pipe(Effect.provide(makeLayer(workingDir)));
+  });
+
+  it.effect(
+    "reports a conflict when a later lesson builds on the deleted one",
+    () => {
+      const { workingDir } = makeConflictingRepo();
+
+      return Effect.gen(function* () {
+        const { result } = yield* deleteLesson("add-second");
+        expect(result.conflict).toBe(true);
+        expect(yield* conflictedFiles).toContain("shared.txt");
+      }).pipe(Effect.provide(makeLayer(workingDir)));
+    }
+  );
+
+  it.effect(
+    "unwinds a conflicted delete back to the original stack",
+    () => {
+      const { workingDir } = makeConflictingRepo();
+
+      return Effect.gen(function* () {
+        const before = git(
+          workingDir,
+          "rev-parse",
+          "live-run-through"
+        );
+
+        const { result, session } = yield* deleteLesson(
+          "add-second"
+        );
+        expect(result.conflict).toBe(true);
+
+        yield* unwind(session, {
+          midCherryPick: true,
+          liveBranchMoved: false,
+          keepTempBranch: false,
+        });
+
+        expect(
+          git(workingDir, "rev-parse", "live-run-through")
+        ).toBe(before);
+        expect(stackOf(workingDir)).toEqual([
+          "add-first: First",
+          "add-second: Second",
+          "add-third: Third",
+        ]);
+      }).pipe(Effect.provide(makeLayer(workingDir)));
+    }
+  );
+});

--- a/test/helpers/make-layer.ts
+++ b/test/helpers/make-layer.ts
@@ -1,0 +1,59 @@
+import { NodeContext, NodeFileSystem } from "@effect/platform-node";
+import { Layer } from "effect";
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import {
+  GitService,
+  GitServiceConfig,
+  makeGitService,
+} from "../../src/git-service.js";
+
+/** A real GitService pointed at a temp repo. */
+export const makeLayer = (workingDir: string) => {
+  const deps = Layer.mergeAll(
+    NodeFileSystem.layer,
+    Layer.succeed(GitServiceConfig, { cwd: workingDir })
+  );
+
+  return Layer.mergeAll(
+    Layer.effect(GitService, makeGitService).pipe(
+      Layer.provide(deps)
+    ),
+    NodeFileSystem.layer,
+    Layer.succeed(GitServiceConfig, { cwd: workingDir }),
+    NodeContext.layer
+  );
+};
+
+export const git = (cwd: string, ...args: Array<string>) =>
+  execFileSync("git", args, {
+    cwd,
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@test.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@test.com",
+    },
+  })
+    .toString()
+    .trim();
+
+export const bareDirOf = (workingDir: string) =>
+  path.resolve(workingDir, "..", "bare.git");
+
+/** The lesson stack's subjects, in teaching order. */
+export const stackOf = (
+  workingDir: string,
+  branch = "live-run-through"
+) =>
+  git(
+    workingDir,
+    "log",
+    "--format=%s",
+    "--reverse",
+    `main..${branch}`
+  )
+    .split("\n")
+    .filter(Boolean);

--- a/test/rename-commit.test.ts
+++ b/test/rename-commit.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { resolveCommitRef } from "../src/branch-commits.js";
+import {
+  beginRenameSession,
+  renameSubject,
+} from "../src/internal/rename-commit/session.js";
+import {
+  applyToLiveBranch,
+  finish,
+  loadCommits,
+} from "../src/internal/stack/session.js";
+import { composeSubject } from "../src/internal/stack/slug.js";
+import {
+  commit,
+  createTestRepo,
+} from "./helpers/create-test-repo.js";
+import { git, makeLayer, stackOf } from "./helpers/make-layer.js";
+
+describe("rename-commit session", () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  const makeRepo = () => {
+    const repo = createTestRepo()
+      .withRemote("origin")
+      .withBranch("main", [
+        commit("base", { "base.txt": "base" }),
+      ])
+      .withBranch("live-run-through", [
+        commit("add-first: First", { "a.txt": "first" }),
+        commit("add-second: Second", { "b.txt": "second" }),
+        commit("add-third: Third", { "c.txt": "third" }),
+      ])
+      .build();
+    cleanup = repo.cleanup;
+    return repo;
+  };
+
+  const renameTo = (ref: string, subject: string) =>
+    Effect.gen(function* () {
+      const commits = yield* loadCommits({
+        branch: "live-run-through",
+        mainBranch: "main",
+      });
+      const target = resolveCommitRef(commits, ref)!;
+
+      const session = yield* beginRenameSession({
+        commits,
+        target,
+        liveBranch: "live-run-through",
+      });
+
+      const result = yield* renameSubject({ session, subject });
+      expect(result.conflict).toBe(false);
+
+      yield* applyToLiveBranch(session);
+      yield* finish(session);
+      return session;
+    });
+
+  it.effect("renames a mid-stack lesson", () => {
+    const { workingDir } = makeRepo();
+    const subject = composeSubject({
+      slug: "add-second-renamed",
+      title: "Renamed",
+    });
+
+    return renameTo("add-second", subject).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(stackOf(workingDir)).toEqual([
+            "add-first: First",
+            subject,
+            "add-third: Third",
+          ]);
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("leaves the lesson's tree untouched", () => {
+    const { workingDir } = makeRepo();
+    const subject = composeSubject({
+      slug: "add-second-renamed",
+      title: "Renamed",
+    });
+
+    return renameTo("add-second", subject).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(
+            git(workingDir, "show", "live-run-through:b.txt")
+          ).toBe("second");
+          // The renamed commit still introduces exactly its own file.
+          const changed = git(
+            workingDir,
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            "live-run-through~1"
+          );
+          expect(changed).toBe("b.txt");
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("renames the tip, replaying nothing", () => {
+    const { workingDir } = makeRepo();
+    const subject = composeSubject({
+      slug: "add-third-renamed",
+      title: "Last",
+    });
+
+    return renameTo("add-third", subject).pipe(
+      Effect.tap((session) =>
+        Effect.sync(() => {
+          expect(session.following).toBe(0);
+          expect(stackOf(workingDir)).toEqual([
+            "add-first: First",
+            "add-second: Second",
+            subject,
+          ]);
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("retitles without changing the slug", () => {
+    const { workingDir } = makeRepo();
+    const subject = composeSubject({
+      slug: "add-second",
+      title: "A better title",
+    });
+
+    return renameTo("add-second", subject).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(stackOf(workingDir)).toEqual([
+            "add-first: First",
+            "add-second: A better title",
+            "add-third: Third",
+          ]);
+        })
+      ),
+      Effect.provide(makeLayer(workingDir))
+    );
+  });
+
+  it.effect("renames an empty placeholder lesson", () => {
+    const repo = createTestRepo()
+      .withRemote("origin")
+      .withBranch("main", [
+        commit("base", { "base.txt": "base" }),
+      ])
+      .withBranch("live-run-through", [
+        commit("add-first: First", { "a.txt": "first" }),
+        commit("add-stub: Stub", {}),
+      ])
+      .build();
+    cleanup = repo.cleanup;
+
+    const subject = composeSubject({
+      slug: "add-stub",
+      title: "Filled in later",
+    });
+
+    return renameTo("add-stub", subject).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(stackOf(repo.workingDir)).toEqual([
+            "add-first: First",
+            subject,
+          ]);
+        })
+      ),
+      Effect.provide(makeLayer(repo.workingDir))
+    );
+  });
+});

--- a/test/slug.test.ts
+++ b/test/slug.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "@effect/vitest";
+import type { BranchCommit } from "../src/branch-commits.js";
+import {
+  checkSlug,
+  composeSubject,
+} from "../src/internal/stack/slug.js";
+
+const lesson = (
+  lessonId: string,
+  sequence: number
+): BranchCommit => ({
+  sha: `sha${sequence}`,
+  message: `${lessonId}: A lesson`,
+  lessonId,
+  description: "A lesson",
+  sequence,
+});
+
+const commits = [
+  lesson("add-first", 1),
+  lesson("add-second", 2),
+];
+
+const check = (
+  slug: string,
+  allowExisting?: string | undefined
+) => checkSlug({ slug, commits, allowExisting });
+
+describe("checkSlug", () => {
+  it("accepts a kebab-case slug that is not taken", () => {
+    expect(check("add-settings-json")).toEqual({ ok: true });
+  });
+
+  it("accepts digits", () => {
+    expect(check("grill-me-2")).toEqual({ ok: true });
+  });
+
+  it("rejects an empty slug", () => {
+    expect(check("  ")).toMatchObject({ ok: false });
+  });
+
+  it("rejects the parse boundary", () => {
+    const result = check("broken: slug");
+    expect(result.ok).toBe(false);
+    expect((result as { reason: string }).reason).toContain(
+      "parse boundary"
+    );
+  });
+
+  it.each([
+    "Add-Settings",
+    "add_settings",
+    "add settings",
+    "-leading",
+    "trailing-",
+    "double--dash",
+  ])("rejects %s as not kebab-case", (slug) => {
+    expect(check(slug)).toMatchObject({ ok: false });
+  });
+
+  it("rejects a slug already used by another lesson", () => {
+    const result = check("add-second");
+    expect(result.ok).toBe(false);
+    expect((result as { reason: string }).reason).toContain(
+      "unique"
+    );
+  });
+
+  it("allows a commit to keep its own slug when renaming", () => {
+    expect(check("add-second", "add-second")).toEqual({
+      ok: true,
+    });
+  });
+
+  it("still rejects another lesson's slug when renaming", () => {
+    expect(check("add-first", "add-second")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(check("  add-third  ")).toEqual({ ok: true });
+  });
+});
+
+describe("composeSubject", () => {
+  it("joins slug and title at the parse boundary", () => {
+    expect(
+      composeSubject({ slug: "add-db", title: "Set up the DB" })
+    ).toBe("add-db: Set up the DB");
+  });
+
+  it("trims both halves", () => {
+    expect(
+      composeSubject({ slug: " add-db ", title: " Set up " })
+    ).toBe("add-db: Set up");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,13 @@ export default defineConfig({
         "src/git-service.ts",
         "src/prompt-service.ts",
         "src/internal/internal.ts",
-        "src/internal/edit-commit/command.ts"
+        "src/internal/edit-commit/command.ts",
+        "src/internal/add-commit/command.ts",
+        "src/internal/rename-commit/command.ts",
+        "src/internal/delete-commit/command.ts",
+        "src/internal/stack/ceremony.ts",
+        "src/internal/stack/options.ts",
+        "src/internal/stack/target.ts"
       ]
     }
   }


### PR DESCRIPTION
`internal` was a namespace of one. Editing a lesson's contents was the only history rewrite the CLI could do — creating, renaming or removing a lesson meant dropping to an interactive rebase by hand.

Assumes every target repo has migrated to slugs.

## The three new commands

**`add-commit`** — prompts for a **slug**, then a **title**, and composes the `slug: Title` subject. A commit *body* would be invisible: every consumer reads `git log --oneline`, and `splitLessonId` parses the subject at the first `": "`. Then it asks where the lesson goes, with "at the start" pinned to the top of the picker and "at the end" pinned to the bottom. It commits an empty stub for `edit-commit` to fill in later — which survives every subsequent replay, since `cherryPick` already passes `--keep-redundant-commits`.

Alone among the four it tolerates an empty stack: "there are no lessons yet" is a perfectly good state to add the first one from. The other three still fail loudly on `NoCommitsFoundError`.

**`rename-commit`** — changes a lesson's slug and title, each prompt prefilled with the current value, so Enter-Enter is a no-op. It amends in place rather than rebuilding from the parent, so a rename can never alter a lesson's contents.

Reslugging is a breaking change for humans — recorded footage that names a slug silently desyncs — but not for machines: nothing in the CVM or the AI Hero CMS pins a SHA *or* a lesson slug. That risk is accepted deliberately.

**`delete-commit`** — removes a lesson and replays the rest onto its parent. Shows the diffstat behind an extra up-front confirmation and takes a `backup/live-run-through-pre-delete-commit-<ts>` branch before touching anything. It's the only command that destroys authored work rather than moving it, and the diffstat is what tells you whether later lessons build on what you're dropping. A conflict during its replay usually means exactly that — the tool working, not failing.

## Slug validation

The first place in the CLI where the slug convention is enforced in code rather than prose — every other command reuses a message that already exists, so nothing has ever had to validate one. Rejects non-kebab-case, anything containing `": "` (it *is* the parse boundary), and duplicates within `main..live-run-through`, since `reset` silently picks the latest of a duplicate pair.

## The menu

A bare `ai-hero internal` opens a picker of the four: edit, add, rename, delete — edit first because it's the daily one, delete last so a stray Enter can't reach it. `@effect/cli` runs a parent's own handler when it's invoked without a subcommand, so this costs no restructuring; naming a subcommand still dispatches straight to it. It accepts `--branch`/`--main-branch` and passes them down, deliberately does *not* hoist `--commit`, and runs one command then exits rather than looping back to a repo state that has just been force-pushed and not re-read. Outside a TTY it prints the command list, exactly as bare `internal` did before.

## The refactor

The temp-branch → replay → apply → publish → unwind spine moves into `src/internal/stack/` and all four commands share it, `edit-commit` included. One `unwind` rather than four — divergent unwind logic is exactly how the orphaned `matt/edit-commit-*` branches came back. Each command body is also a plain exported function, so the CLI subcommand and the menu run one implementation.

This is the part of the PR that can regress something in daily use. The existing 750-line `test/edit-commit.test.ts` is the regression check and is unmodified.

## Verification

- `pnpm test` — **153 passed** (was 119; the pre-existing suite is untouched and green)
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Built and smoke-tested `dist/bin.cjs`: bare `internal` prints the list and exits 0 without a TTY, `internal --help` lists all four subcommands, `internal add-commit --help` dispatches, and `internal add-commit` without a TTY refuses with the expected error.

New tests cover insertion at start/middle/end, the stub actually being empty, replayed lessons keeping their contents, the empty-stack first lesson, publishing to origin, rename mid-stack/tip/retitle-only/placeholder with the tree left untouched, delete at head/tip/middle, the backup branch naming the pre-delete tip, and a conflicting delete both reporting its conflict and unwinding cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)