### PR TITLE
feat(internal): show an empty notice for contentless lesson commits

### DIFF
--- a/.changeset/lucky-pets-repeat.md
+++ b/.changeset/lucky-pets-repeat.md
@@ -1,0 +1,5 @@
+---
+"ai-hero-cli": minor
+---
+
+`edit-commit` and `delete-commit` now mark lessons that carry no content. A placeholder commit shows an "(empty — no content)" notice in front of its description in the picker, so you can tell before you choose it.

--- a/src/branch-commits.ts
+++ b/src/branch-commits.ts
@@ -16,6 +16,12 @@ export interface BranchCommit {
   description: string;
   /** 1-based position in teaching order. Ordering only — never identity. */
   sequence: number;
+  /**
+   * True when the commit changes no files — a lesson placeholder that carries
+   * no content yet. Surfaced in the picker so you can tell, before editing or
+   * deleting, whether there is anything in there.
+   */
+  isEmpty: boolean;
 }
 
 export class NoCommitsFoundError extends Data.TaggedError(
@@ -46,15 +52,32 @@ export const getCommitsBetweenBranches = (opts: {
   Effect.gen(function* () {
     const git = yield* GitService;
 
-    const commitHistory = yield* git.getLogOnelineReverse(
-      `${opts.mainBranch}..${opts.liveBranch}`
-    );
+    const range = `${opts.mainBranch}..${opts.liveBranch}`;
 
-    const commits: Array<BranchCommit> = commitHistory
+    const commitHistory = yield* git.getLogOnelineReverse(range);
+
+    const subjects = commitHistory
       .trim()
       .split("\n")
-      .filter(Boolean)
-      .map((line, index) => {
+      .filter(Boolean);
+
+    if (subjects.length === 0) {
+      return yield* Effect.fail(
+        new NoCommitsFoundError({
+          mainBranch: opts.mainBranch,
+          liveBranch: opts.liveBranch,
+        })
+      );
+    }
+
+    // Asked for only once there is something to describe, so an empty stack
+    // still costs one git read.
+    const emptyShas = new Set(
+      yield* git.getEmptyCommitShas(range)
+    );
+
+    const commits: Array<BranchCommit> = subjects.map(
+      (line, index) => {
         const [sha, ...messageParts] = line.split(" ");
         const message = messageParts.join(" ");
         const { description, lessonId } =
@@ -66,17 +89,10 @@ export const getCommitsBetweenBranches = (opts: {
           lessonId,
           description,
           sequence: index + 1,
+          isEmpty: emptyShas.has(sha!),
         };
-      });
-
-    if (commits.length === 0) {
-      return yield* Effect.fail(
-        new NoCommitsFoundError({
-          mainBranch: opts.mainBranch,
-          liveBranch: opts.liveBranch,
-        })
-      );
-    }
+      }
+    );
 
     return commits;
   });
@@ -131,6 +147,7 @@ export const selectCommit = (opts: {
       lessons.map((commit) => ({
         lessonId: commit.lessonId!,
         message: commit.description,
+        isEmpty: commit.isEmpty,
       })),
       opts.promptMessage
     );

--- a/src/git-service/git-service-impl.ts
+++ b/src/git-service/git-service-impl.ts
@@ -351,6 +351,40 @@ export const makeGitService = Effect.gen(function* () {
           }
         ),
 
+        /**
+         * The shas in `range` that change no files — placeholder lessons with
+         * no content authored into them yet.
+         *
+         * One `git log` rather than a `diff-tree` per commit. The NUL before
+         * each sha keeps the commit boundary unambiguous even when a changed
+         * path looks like a sha, and `--no-merges` keeps merges out: they list
+         * no paths in this format and would read as empty.
+         */
+        getEmptyCommitShas: Effect.fn("getEmptyCommitShas")(
+          function* (range: string) {
+            const log = yield* runCommandWithString(
+              "git",
+              "log",
+              "--reverse",
+              "--no-merges",
+              "--format=%x00%h",
+              "--name-only",
+              range
+            );
+
+            return log
+              .split("\0")
+              .map((entry) => entry.trim())
+              .filter(Boolean)
+              .flatMap((entry) => {
+                const [sha, ...files] = entry.split("\n");
+                return files.some((file) => file.trim())
+                  ? []
+                  : [sha!];
+              });
+          }
+        ),
+
         getLogOneline: Effect.fn("getLogOneline")(function* (
           branch: string
         ) {

--- a/src/prompt-service.ts
+++ b/src/prompt-service.ts
@@ -310,6 +310,9 @@ export class PromptService extends Effect.Service<PromptService>()(
       /**
        * Autocomplete prompt for selecting a lesson commit.
        *
+       * A commit marked `isEmpty` gets an "(empty)" notice in front of its
+       * description, so a placeholder lesson is obvious before you pick it.
+       *
        * @param commits - Array of commits with lessonId and message
        * @param promptMessage - Custom prompt message to display
        * @returns The selected lesson ID string
@@ -317,7 +320,11 @@ export class PromptService extends Effect.Service<PromptService>()(
        */
       const selectLessonCommit = Effect.fn("selectLessonCommit")(
         function* (
-          commits: Array<{ lessonId: string; message: string }>,
+          commits: Array<{
+            lessonId: string;
+            message: string;
+            isEmpty?: boolean;
+          }>,
           promptMessage: string
         ) {
           const { lesson } = yield* runPrompt<{
@@ -331,7 +338,10 @@ export class PromptService extends Effect.Service<PromptService>()(
                 choices: commits.map((commit) => ({
                   title: commit.lessonId,
                   value: commit.lessonId,
-                  description: commit.message,
+                  description: commit.isEmpty
+                    ? `(empty — no content) ${commit.message}`
+                        .trim()
+                    : commit.message,
                 })),
                 suggest: async (
                   input: string,

--- a/test/branch-commits.test.ts
+++ b/test/branch-commits.test.ts
@@ -28,6 +28,11 @@ describe("branch-commits", () => {
                 return "abc123 add-first: First lesson\ndef456 01.02.01: Second lesson\nghi789 no lesson prefix";
               }
             ),
+            getEmptyCommitShas: Effect.fn("getEmptyCommitShas")(
+              function* () {
+                return [];
+              }
+            ),
           });
 
           const testLayer = Layer.mergeAll(
@@ -47,6 +52,7 @@ describe("branch-commits", () => {
               lessonId: "add-first",
               description: "First lesson",
               sequence: 1,
+              isEmpty: false,
             },
             {
               sha: "def456",
@@ -54,6 +60,7 @@ describe("branch-commits", () => {
               lessonId: "01.02.01",
               description: "Second lesson",
               sequence: 2,
+              isEmpty: false,
             },
             // No ": " boundary — not a lesson, so it carries no id.
             {
@@ -62,7 +69,48 @@ describe("branch-commits", () => {
               lessonId: null,
               description: "no lesson prefix",
               sequence: 3,
+              isEmpty: false,
             },
+          ]);
+        })
+    );
+
+    it.effect(
+      "should mark the commits that change no files as empty",
+      () =>
+        Effect.gen(function* () {
+          const mockGitService = fromPartial<GitService>({
+            getLogOnelineReverse: Effect.fn(
+              "getLogOnelineReverse"
+            )(function* () {
+              return "abc123 add-first: First lesson\ndef456 add-second: Placeholder";
+            }),
+            getEmptyCommitShas: Effect.fn("getEmptyCommitShas")(
+              function* (range: string) {
+                expect(range).toBe("main..live-run-through");
+                return ["def456"];
+              }
+            ),
+          });
+
+          const testLayer = Layer.mergeAll(
+            Layer.succeed(GitService, mockGitService),
+            NodeContext.layer
+          );
+
+          const commits = yield* getCommitsBetweenBranches({
+            mainBranch: "main",
+            liveBranch: "live-run-through",
+          }).pipe(Effect.provide(testLayer));
+
+          expect(
+            commits.map((commit) => [
+              commit.lessonId,
+              commit.isEmpty,
+            ])
+          ).toEqual([
+            ["add-first", false],
+            ["add-second", true],
           ]);
         })
     );

--- a/test/empty-commits.test.ts
+++ b/test/empty-commits.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { loadCommits } from "../src/internal/stack/session.js";
+import {
+  commit,
+  createTestRepo,
+} from "./helpers/create-test-repo.js";
+import { makeLayer } from "./helpers/make-layer.js";
+
+/**
+ * A placeholder lesson — a commit with a message and no content — must be
+ * visible as such before you edit or delete it. Tested against a real repo,
+ * because the emptiness comes from git, not from the subject line.
+ */
+describe("empty lesson commits", () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it.effect(
+    "should mark commits that carry no content as empty",
+    () =>
+      Effect.gen(function* () {
+        const repo = createTestRepo()
+          .withRemote("origin")
+          .withBranch("main", [
+            commit("base", { "base.txt": "base" }),
+          ])
+          .withBranch("live-run-through", [
+            commit("add-first: First", { "a.txt": "first" }),
+            commit("add-second: Placeholder", {}),
+            commit("add-third: Third", { "c.txt": "third" }),
+          ])
+          .build();
+        cleanup = repo.cleanup;
+
+        const commits = yield* loadCommits({
+          branch: "live-run-through",
+          mainBranch: "main",
+        }).pipe(Effect.provide(makeLayer(repo.workingDir)));
+
+        expect(
+          commits.map((entry) => [
+            entry.lessonId,
+            entry.isEmpty,
+          ])
+        ).toEqual([
+          ["add-first", false],
+          ["add-second", true],
+          ["add-third", false],
+        ]);
+      })
+  );
+});


### PR DESCRIPTION
## What

When you pick a lesson in `ai-hero internal edit-commit` or `delete-commit`, the picker now tells you if that commit has no content. A placeholder lesson reads:

```
add-second   (empty — no content) Placeholder
```

## How

- `GitService.getEmptyCommitShas(range)` — one `git log --name-only` read that reports the shas that change no files. A NUL before each sha keeps the commit boundary unambiguous; `--no-merges` keeps merges out, because they list no paths in this format and would read as empty.
- `BranchCommit.isEmpty` carries the flag through `getCommitsBetweenBranches`.
- `selectLessonCommit` puts the notice in front of the description. The field is optional, so the `reset` and `cherry-pick` pickers are unchanged.

## Tests

- Unit: `getCommitsBetweenBranches` marks the reported shas.
- Real repo: a `commit("add-second: Placeholder", {})` in the stack comes back as empty.

`pnpm typecheck`, `pnpm lint` and `pnpm test` (155 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)