### PR TITLE
feat(internal): show an emoji for contentless lesson commits

### DIFF
--- a/.changeset/lucky-pets-repeat.md
+++ b/.changeset/lucky-pets-repeat.md
@@ -2,4 +2,4 @@
 "ai-hero-cli": minor
 ---
 
-`edit-commit` and `delete-commit` now mark lessons that carry no content. A placeholder commit shows an "(empty — no content)" notice in front of its description in the picker, so you can tell before you choose it.
+`edit-commit`, `delete-commit`, `rename-commit` and `add-commit` now mark lessons that carry no content. A placeholder commit shows a 📭 "(empty — no content)" notice in front of its description in the picker, so it reads as visibly empty rather than blank before you choose it.

--- a/src/internal/add-commit/command.ts
+++ b/src/internal/add-commit/command.ts
@@ -44,6 +44,7 @@ const askPosition = (commits: Array<BranchCommit>) =>
       lessons.map((commit) => ({
         lessonId: commit.lessonId!,
         message: commit.description,
+        isEmpty: commit.isEmpty,
       }))
     );
 

--- a/src/prompt-service.ts
+++ b/src/prompt-service.ts
@@ -20,6 +20,16 @@ const runPrompt = <T extends object>(
 };
 
 /**
+ * Prefixes a lesson's description with a 📭 notice when its commit carries no
+ * content — a placeholder lesson stub. Emoji + text (not just text) so it
+ * reads as visibly empty in the list rather than blank when you're picking a
+ * commit, not just something you'd notice if you read the gray description
+ * text carefully.
+ */
+const emptyCommitNotice = (message: string) =>
+  `📭 (empty — no content) ${message}`.trim();
+
+/**
  * Normalizes exercise numbers for fuzzy matching.
  * Generates variations like "02.03" -> ["02.03", "0203", "2.3", "23", etc.]
  */
@@ -310,8 +320,9 @@ export class PromptService extends Effect.Service<PromptService>()(
       /**
        * Autocomplete prompt for selecting a lesson commit.
        *
-       * A commit marked `isEmpty` gets an "(empty)" notice in front of its
-       * description, so a placeholder lesson is obvious before you pick it.
+       * A commit marked `isEmpty` gets a 📭 "(empty — no content)" notice in
+       * front of its description, so a placeholder lesson is obvious before
+       * you pick it.
        *
        * @param commits - Array of commits with lessonId and message
        * @param promptMessage - Custom prompt message to display
@@ -339,8 +350,7 @@ export class PromptService extends Effect.Service<PromptService>()(
                   title: commit.lessonId,
                   value: commit.lessonId,
                   description: commit.isEmpty
-                    ? `(empty — no content) ${commit.message}`
-                        .trim()
+                    ? emptyCommitNotice(commit.message)
                     : commit.message,
                 })),
                 suggest: async (
@@ -829,6 +839,10 @@ export class PromptService extends Effect.Service<PromptService>()(
        * The two boundary choices are pinned: "at the start" first, "at the
        * end" last, with the existing lessons in teaching order between them.
        *
+       * A lesson marked `isEmpty` gets the same 📭 "(empty — no content)"
+       * notice as `selectLessonCommit`, so inserting after a placeholder
+       * lesson is an informed choice, not a guess.
+       *
        * @param lessons - Existing lessons, in teaching order
        * @returns "start", "end", or the lesson id to insert after
        * @throws PromptCancelledError if user presses Ctrl+C
@@ -836,7 +850,11 @@ export class PromptService extends Effect.Service<PromptService>()(
       const selectInsertPosition = Effect.fn(
         "selectInsertPosition"
       )(function* (
-        lessons: Array<{ lessonId: string; message: string }>
+        lessons: Array<{
+          lessonId: string;
+          message: string;
+          isEmpty?: boolean;
+        }>
       ) {
         const START = " start";
         const END = " end";
@@ -850,7 +868,9 @@ export class PromptService extends Effect.Service<PromptService>()(
           ...lessons.map((lesson) => ({
             title: `after ${lesson.lessonId}`,
             value: lesson.lessonId,
-            description: lesson.message,
+            description: lesson.isEmpty
+              ? emptyCommitNotice(lesson.message)
+              : lesson.message,
           })),
           {
             title: "── at the end ──",

--- a/src/prompt-service.ts
+++ b/src/prompt-service.ts
@@ -20,6 +20,17 @@ const runPrompt = <T extends object>(
 };
 
 /**
+ * A lesson as offered to a commit-picker: `selectLessonCommit` (edit/delete/
+ * rename-commit) and `selectInsertPosition` (add-commit) both list lessons by
+ * this same shape, so it's named once rather than repeated per signature.
+ */
+type LessonCommitOption = {
+  lessonId: string;
+  message: string;
+  isEmpty?: boolean;
+};
+
+/**
  * Prefixes a lesson's description with a 📭 notice when its commit carries no
  * content — a placeholder lesson stub. Emoji + text (not just text) so it
  * reads as visibly empty in the list rather than blank when you're picking a
@@ -331,11 +342,7 @@ export class PromptService extends Effect.Service<PromptService>()(
        */
       const selectLessonCommit = Effect.fn("selectLessonCommit")(
         function* (
-          commits: Array<{
-            lessonId: string;
-            message: string;
-            isEmpty?: boolean;
-          }>,
+          commits: Array<LessonCommitOption>,
           promptMessage: string
         ) {
           const { lesson } = yield* runPrompt<{
@@ -849,13 +856,7 @@ export class PromptService extends Effect.Service<PromptService>()(
        */
       const selectInsertPosition = Effect.fn(
         "selectInsertPosition"
-      )(function* (
-        lessons: Array<{
-          lessonId: string;
-          message: string;
-          isEmpty?: boolean;
-        }>
-      ) {
+      )(function* (lessons: Array<LessonCommitOption>) {
         const START = " start";
         const END = " end";
 


### PR DESCRIPTION
## Summary
- The empty-commit notice added in #75 (`edit-commit`/`delete-commit`'s picker) was text-only — `"(empty — no content)"` in the gray description line, easy to skim past. Prefix it with 📭 so a placeholder lesson reads as visibly empty rather than blank at a glance.
- Extend the same notice to `add-commit`'s insert-position picker, which didn't surface emptiness at all before this. `rename-commit` already inherited it via the shared `resolveTarget`/`selectCommit` path.
- All four internal pickers (`edit-commit`, `delete-commit`, `rename-commit`, `add-commit`) now show the notice consistently.

The emoji lives only in each choice's `description`, never in `title` — `title` still doubles as the raw lesson id, which the autocomplete's numeric fuzzy-match regex builds directly from, so keeping it emoji-free avoids breaking search for numeric lesson ids.

Updated the pending `.changeset/lucky-pets-repeat.md` (still unreleased) to describe the emoji and the wider `add-commit` coverage, rather than stacking a second changeset on the same unreleased feature.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (155 tests passing)