### PR TITLE
fix: inherit stdin in git/gh command wrappers so commit signing doesn't hang

### DIFF
--- a/.changeset/quiet-signs-listen.md
+++ b/.changeset/quiet-signs-listen.md
@@ -1,0 +1,5 @@
+---
+"ai-hero-cli": patch
+---
+
+Commands that create a commit no longer hang when git commit signing is enabled. `fork`, `cherry-pick`, `pull` and the internal `add-commit`/`edit-commit`/`rename-commit`/`delete-commit` flows now inherit stdin, so a GPG or SSH signing tool can prompt for your key's passphrase on your terminal instead of blocking forever on a disconnected pipe. The same fix applies to the `gh repo create --push` step of `fork`, which could hang if the push needed an SSH key passphrase.

--- a/src/git-service/git-service-impl.ts
+++ b/src/git-service/git-service-impl.ts
@@ -64,6 +64,10 @@ export const makeGitService = Effect.gen(function* () {
         const cwd = config.cwd;
         const command = Command.make(...commandArgs).pipe(
           Command.workingDirectory(cwd),
+          // stdin is inherited so commit signing (GPG/SSH) can read its
+          // passphrase prompt from the user's terminal instead of hanging
+          // forever on a disconnected pipe.
+          Command.stdin("inherit"),
           Command.stdout("inherit"),
           Command.stderr("inherit")
         );

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -70,6 +70,10 @@ export const makeGitHubService = Effect.gen(function* () {
     function* (...commandArgs: [string, ...Array<string>]) {
       const command = Command.make(...commandArgs).pipe(
         Command.workingDirectory(config.cwd),
+        // stdin is inherited so a push needing an SSH key passphrase can
+        // prompt on the user's terminal instead of hanging forever on a
+        // disconnected pipe.
+        Command.stdin("inherit"),
         Command.stdout("inherit"),
         Command.stderr("inherit")
       );


### PR DESCRIPTION
> [!NOTE]
> I discovered this while working through the AI coding crash course and thought that it'd be a good candidate to practice the workflow. The original issues are therefore under my account:
> 
> * https://github.com/clinton3141/ai-hero-cli/issues/2
> * https://github.com/clinton3141/ai-hero-cli/issues/3
> * https://github.com/clinton3141/ai-hero-cli/issues/4
> 
> I'm happy to recreate them on this repo if you'd prefer.  

## Problem

With git commit signing (GPG or SSH) enabled, `npx ai-hero-cli fork` hangs indefinitely instead of prompting for the signing key's passphrase — no visible prompt, no error, no timeout. The student just sees it sit there.

The shared command wrappers already inherit `stdout` and `stderr`, but leave `stdin` as a disconnected, never-fed pipe. When the signing tool (gpg-agent/pinentry, or ssh-agent) tries to read the passphrase back through the child git process's stdin, it blocks on that pipe forever.

## Fix

Add `Command.stdin("inherit")` at the two shared wrappers, so the native prompt reaches the user's terminal:

- **`GitService.runCommandWithExitCode`** — covers `fork`, `cherry-pick`, `pull` (merge commits), and the internal `add-commit` / `edit-commit` / `rename-commit` / `delete-commit` flows
- **`GitHubService.runInheritExitCode`** — covers the `gh repo create ... --push` step of `fork`, which can hang identically if the push needs an SSH key passphrase

Applied at the wrapper level rather than per-command, so commands added later don't reintroduce the hang.

Two deliberate non-changes:

- The read-only git-config probe wrapper (`runCommandSilentExitCode`) is left untouched — no interactive exposure, so no reason to widen its blast radius.
- No CLI-authored hint message ("this may prompt for a passphrase") before signing operations. It'd be inaccurate across the range of signing setups (GPG vs SSH, loopback vs GUI pinentry); the native prompt speaks for itself.

## Verification

No automated test. Inherited stdio/TTY interaction with a real signing agent isn't meaningfully simulable without a pty, and a test asserting the stdin config was set wouldn't exercise the actual risk. Happy to add one if you'd prefer it anyway.

Verified manually instead — the real `GitService.commit()` driven against a scratch repo with SSH signing enabled, stdin from `/dev/null`, under a 20s alarm:

| | result |
|---|---|
| without fix | hung, killed at 20s |
| with fix | completed in 1s |

Confirmed at the library level too: `Command.stdin(cmd, "inherit")` maps to `stdio[0] = "inherit"` in the platform-node executor, where the default is a pipe that's never fed.

Full suite passes (155/155), typecheck and lint clean. A changeset is included.

## Note for reviewers

`pnpm test` fails 94 tests on any machine with commit signing enabled globally. `test/helpers/create-test-repo.ts` spawns git with `stdio: "pipe"`, so fixture commits can't sign. This is **pre-existing and unrelated** to this change — I verified the failures are identical with and without it, by stashing. A clean run needs:

```
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm test
```

Probably worth fixing separately — the helper should pass `--no-gpg-sign`, since fixtures have no reason to sign. Left out of this PR to keep it focused. Glad to send it as a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CpL3BpZSU4SmsRJm4ByjX