### PR TITLE
reset: warn when Windows symlink fallback will break a lesson

### DIFF
--- a/.changeset/tame-cows-drum.md
+++ b/.changeset/tame-cows-drum.md
@@ -1,0 +1,5 @@
+---
+"ai-hero-cli": minor
+---
+
+`reset` now warns when a lesson's symlinks won't check out correctly. On Windows, without Developer Mode or admin rights, Git falls back to `core.symlinks=false` and writes symlinked paths (e.g. `.claude/skills`) as plain text files instead of real links. If the selected lesson has git-tracked symlinks and that fallback is active, `reset` prints how to fix it (enable Developer Mode or run as Administrator, `git config core.symlinks true`, then reset again) before proceeding.

--- a/src/git-service/git-service-impl.ts
+++ b/src/git-service/git-service-impl.ts
@@ -803,6 +803,38 @@ export const makeGitService = Effect.gen(function* () {
           );
           return exitCode === 0;
         }),
+        /**
+         * True when this repo checks out symlinks as plain text files
+         * instead of real links — `core.symlinks=false`. Git sets this
+         * automatically on Windows when Developer Mode isn't on and the
+         * process isn't elevated, since it can't create symlinks there.
+         * Unset (the common case elsewhere) reads as symlinks working.
+         */
+        hasSymlinksDisabled: Effect.fn("hasSymlinksDisabled")(
+          function* () {
+            const value = yield* runCommandWithString(
+              "git",
+              "config",
+              "--get",
+              "core.symlinks"
+            ).pipe(Effect.catchAll(() => Effect.succeed("")));
+            return value.trim() === "false";
+          }
+        ),
+        /** Whether `ref`'s tree contains any git-tracked symlinks (mode 120000). */
+        commitHasSymlinks: Effect.fn("commitHasSymlinks")(
+          function* (ref: string) {
+            const output = yield* runCommandWithString(
+              "git",
+              "ls-tree",
+              "-r",
+              ref
+            ).pipe(Effect.catchAll(() => Effect.succeed("")));
+            return output
+              .split("\n")
+              .some((line) => line.startsWith("120000 "));
+          }
+        ),
       };
     });
 

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -83,6 +83,31 @@ export const runReset = ({
 
       const isResetToMain = selectedLessonId === "main";
 
+      // Windows checks out a git symlink as a plain text file containing
+      // its target path instead of a real link when Developer Mode isn't
+      // on and the process isn't elevated — git falls back by setting
+      // core.symlinks=false at clone/init time. Warn up front so a
+      // broken-looking course doesn't read as "something is lost".
+      const symlinksDisabled = yield* git.hasSymlinksDisabled();
+      if (symlinksDisabled) {
+        const targetHasSymlinks = yield* git.commitHasSymlinks(
+          commitToUse
+        );
+        if (targetHasSymlinks) {
+          yield* Console.log(
+            "\n⚠ Symlinks are disabled for this repo (core.symlinks=false), " +
+              "which Windows sets automatically when Developer Mode is off and " +
+              "you're not running as Administrator. This lesson includes " +
+              "symlinks, so they'll be checked out as plain text files instead " +
+              "of working links, and the course will look broken.\n" +
+              "  Fix: turn on Developer Mode (Settings > Privacy & security > " +
+              "For developers), or re-run your terminal as Administrator, then:\n" +
+              "    git config core.symlinks true\n" +
+              "  and run `npm run reset` again.\n"
+          );
+        }
+      }
+
       // Cannot reset to main while on main
       if (isResetToMain && currentBranch === "main") {
         return yield* new InvalidBranchOperationError({

--- a/test/reset-e2e.test.ts
+++ b/test/reset-e2e.test.ts
@@ -1,5 +1,5 @@
 import { NodeContext, NodeFileSystem } from "@effect/platform-node";
-import { afterEach, describe, expect, it } from "@effect/vitest";
+import { afterEach, describe, expect, it, vi } from "@effect/vitest";
 import { fromPartial } from "@total-typescript/shoehorn";
 import { Effect, Layer, Option } from "effect";
 import { execFileSync } from "node:child_process";
@@ -544,6 +544,234 @@ describe("reset (e2e)", () => {
             "utf-8"
           );
           expect(content).toBe("// uncommitted changes");
+        })
+    );
+  });
+
+  describe("symlink support warning", () => {
+    it.effect(
+      "should warn when core.symlinks is false and the target lesson has symlinks",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("live-run-through", [
+              commit("01.01.01: Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          // Add a lesson commit that carries a git-tracked symlink, and
+          // push it upstream so reset can fetch it.
+          git(repo.workingDir, "checkout", "live-run-through");
+          fs.symlinkSync(
+            "../.agents/skills",
+            path.join(repo.workingDir, ".claude-skills")
+          );
+          git(repo.workingDir, "add", ".claude-skills");
+          git(
+            repo.workingDir,
+            "commit",
+            "-m",
+            "01.01.02: Add skills symlink"
+          );
+          git(
+            repo.workingDir,
+            "push",
+            "upstream",
+            "live-run-through:live-run-through"
+          );
+          git(repo.workingDir, "checkout", "my-branch");
+
+          // Simulate Windows without Developer Mode / admin rights, where
+          // git falls back to checking symlinks out as plain text files.
+          git(
+            repo.workingDir,
+            "config",
+            "core.symlinks",
+            "false"
+          );
+
+          const consoleSpy = vi
+            .spyOn(console, "log")
+            .mockImplementation(() => {});
+
+          const mockPromptService = fromPartial<PromptService>({
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.some("01.01.02"),
+            demo: false,
+            upstream: getBareRepoPath(repo.workingDir),
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          const loggedLines = consoleSpy.mock.calls.flat();
+          consoleSpy.mockRestore();
+
+          expect(
+            loggedLines.some(
+              (line) =>
+                typeof line === "string" &&
+                line.includes("core.symlinks=false")
+            )
+          ).toBe(true);
+        })
+    );
+
+    it.effect(
+      "should not warn when core.symlinks is false but the target lesson has no symlinks",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("live-run-through", [
+              commit("01.01.01: Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          git(
+            repo.workingDir,
+            "config",
+            "core.symlinks",
+            "false"
+          );
+
+          const consoleSpy = vi
+            .spyOn(console, "log")
+            .mockImplementation(() => {});
+
+          const mockPromptService = fromPartial<PromptService>({
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.some("01.01.01"),
+            demo: false,
+            upstream: getBareRepoPath(repo.workingDir),
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          const loggedLines = consoleSpy.mock.calls.flat();
+          consoleSpy.mockRestore();
+
+          expect(
+            loggedLines.some(
+              (line) =>
+                typeof line === "string" &&
+                line.includes("core.symlinks=false")
+            )
+          ).toBe(false);
+        })
+    );
+
+    it.effect(
+      "should not warn when the lesson has symlinks but core.symlinks is left enabled",
+      () =>
+        Effect.gen(function* () {
+          const repo = createTestRepo()
+            .withRemote("upstream")
+            .withBranch("live-run-through", [
+              commit("01.01.01: Arrays intro", {
+                "src/01.ts": "// arrays intro",
+              }),
+            ])
+            .withWorkingBranch("my-branch", {
+              from: "live-run-through",
+              atCommit: 0,
+            })
+            .build();
+
+          cleanup = repo.cleanup;
+          configureGitUser(repo.workingDir);
+
+          git(repo.workingDir, "checkout", "live-run-through");
+          fs.symlinkSync(
+            "../.agents/skills",
+            path.join(repo.workingDir, ".claude-skills")
+          );
+          git(repo.workingDir, "add", ".claude-skills");
+          git(
+            repo.workingDir,
+            "commit",
+            "-m",
+            "01.01.02: Add skills symlink"
+          );
+          git(
+            repo.workingDir,
+            "push",
+            "upstream",
+            "live-run-through:live-run-through"
+          );
+          git(repo.workingDir, "checkout", "my-branch");
+
+          const consoleSpy = vi
+            .spyOn(console, "log")
+            .mockImplementation(() => {});
+
+          const mockPromptService = fromPartial<PromptService>({
+            selectResetAction: Effect.fn("selectResetAction")(
+              function* () {
+                return "reset-current" as const;
+              }
+            ),
+          });
+
+          yield* runReset({
+            branch: "live-run-through",
+            lessonId: Option.some("01.01.02"),
+            demo: false,
+            upstream: getBareRepoPath(repo.workingDir),
+          }).pipe(
+            Effect.provide(
+              makeLayer(repo.workingDir, mockPromptService)
+            )
+          );
+
+          const loggedLines = consoleSpy.mock.calls.flat();
+          consoleSpy.mockRestore();
+
+          expect(
+            loggedLines.some(
+              (line) =>
+                typeof line === "string" &&
+                line.includes("core.symlinks=false")
+            )
+          ).toBe(false);
         })
     );
   });


### PR DESCRIPTION
## Summary

Prompted by a student thread in #crash-course-questions ("Your Starting Context"): on Windows without Developer Mode/admin rights, Git can't create real symlinks, so it silently swaps in a text-file fallback. Nothing errors — the course just looks broken.

```mermaid
flowchart TD
    A["git checkout<br/>.claude/skills → ../.agents/skills"] --> B{core.symlinks?}
    B -->|"true<br/>(macOS/Linux, or Windows + Developer Mode)"| C["✅ real symlink<br/>.claude/skills resolves to ../.agents/skills"]
    B -->|"false<br/>(Windows, no Developer Mode / not elevated)"| D["❌ 17-byte text file<br/>.claude/skills literally contains '../.agents/skills'"]
```

`reset` now catches case D before it bites: it checks `core.symlinks` and whether the selected lesson's commit tree actually has git-tracked symlinks, and only warns when both are true — so symlink-free repos stay silent.

```mermaid
flowchart TD
    R1["resolve lesson → commitToUse"] --> R2{"core.symlinks=false<br/>AND<br/>commitToUse has tracked symlinks?"}
    R2 -->|no| R4["prompt: reset-current / create-branch"]
    R2 -->|yes| R3["⚠ print fix-it warning:<br/>enable Developer Mode / run elevated →<br/>git config core.symlinks true →<br/>npm run reset again"]
    R3 --> R4
    R4 --> R5["git reset --hard / checkout -b"]
```

- Added `GitService.hasSymlinksDisabled()` and `GitService.commitHasSymlinks(ref)`.
- Warning fires in `reset` right after the target commit is resolved, before any destructive checkout.

Related: https://discordapp.com/channels/1316387060357140520/1543010924032688168/1544284364115025941

## Test plan
- [x] `pnpm test` — 158 passed, including 3 new cases in `test/reset-e2e.test.ts` (`symlink support warning`) covering: warns when disabled + lesson has symlinks; silent when disabled but lesson has none; silent when lesson has symlinks but `core.symlinks` isn't disabled.
- [x] Verified the new tests actually exercise the warning (temporarily stubbed the check to `false` and confirmed the "warn" test fails).
- [x] `pnpm typecheck` and `pnpm lint` clean.
- [x] Added a changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)